### PR TITLE
Code-size reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The basic building block is a property. A property has an ID, a parent, a name a
 example:
 
 ```c++
-ThingSetReadWriteProperty<0x300, 0, "voltage", float> voltage = 24;
+ThingSetReadWriteProperty<float> voltage = 24 { 0x300, 0, "voltage" };
 ```
 
 A property so declared provides its own storage for the given value. Alternatively,
@@ -30,7 +30,7 @@ a property may be declared with a pointer:
 
 ```c++
 float voltage;
-ThingSetReadWriteProperty<0x300, 0, "voltage", float *> voltageProperty(&voltage);
+ThingSetReadWriteProperty<float *> voltageProperty(&voltage) { 0x300, 0, "voltage" };
 ```
 
 Assignment to the property will update the underlying value.
@@ -43,10 +43,10 @@ Structures should be declared thus:
 ```c++
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadOnlyProperty<float> voltage { 0x601, 0x600, "voltage" };
+    ThingSetReadOnlyProperty<float> current { 0x602, 0x600, "current" };
+    ThingSetReadOnlyProperty<uint64_t> error { 0x603, 0x600, "error" };
+    ThingSetReadOnlyProperty<std::array<float, 6>> cellVoltages { 0x604, 0x600, "cellVoltages" };
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,16 @@ Both text (JSON) and binary (CBOR) encodings are supported.
 
 ## Getting Started
 
-The basic building block is a property. A property has an ID, a parent, a name and a type. For
-example:
+### Server
+
+The basic building block is a property. A property has an ID, a parent, a name and a value of a
+certain type. For example:
+
+```c++
+ThingSetReadWriteProperty<float> voltage { 0x300, 0, "voltage" };
+```
+
+The type will be inferred if the value is specified at initialisation:
 
 ```c++
 ThingSetReadWriteProperty voltage { 0x300, 0, "voltage", 24.0f };
@@ -33,7 +41,8 @@ float voltage;
 ThingSetReadWriteProperty voltageProperty { 0x300, 0, "voltage", &voltage };
 ```
 
-Assignment to the property will update the underlying value.
+The type will be inferred from the pointer type. Assignment to the property will update
+the underlying value.
 
 All the basic primitive types are supported. Properties may also be structures*, or arrays of primitives
 or structures (known in C ThingSet as 'records').
@@ -64,25 +73,41 @@ server.listen();
 (* There is no direct equivalent of a single structure being a value in C ThingSet, which may cause
 compatibility problems.)
 
-## Decoding
+### Client
 
-The decoder adopts a typical object-oriented approach. The various overloads of `decode`
-handle most primitive types, C and C++ (i.e. `std::array`) arrays and appropriately-designed complex
-types. Other methods decode maps (`decodeMap`) and lists into a tuple or via a callback for each
-element (`decodeList`).
+The client is instantiated along similar lines:
 
-## Encoding
+```c++
+std::array<uint8_t, 1024> rxBuffer;
+std::array<uint8_t, 1024> txBuffer;
+ThingSetSocketClientTransport clientTransport("127.0.0.1");
+ThingSetClient client(clientTransport, rxBuffer, txBuffer);
+client.connect();
+```
 
-As with the decoder, the encoder adopts a similar object-oriented approach. Various overloads of
-`encode` handle most types. `encodeListStart` and `encodeMapStart` are provided to allow greater
-control over the encoding process.
+Values can then be retrieved:
 
-## Streaming
+```c++
+float voltage;
+if (client.get(0x300, voltage)) {
+    ...
+}
+```
 
-Of particular interest may be the `Streaming...` variants of the encoder and decoder. These allow
-efficient encoding and decoding of streams of data with very little memory footprint. The
-`StreamingCanThingSetBinaryEncoder`, in particular, can encode lengthy multi-frame CAN reports while
-requiring only 128 bytes (i.e. 2 CAN-FD frames' worth) of buffer space.
+...or updated:
+
+```c++
+client.update("voltage", 25.0f);
+```
+
+...and functions invoked:
+
+```c++
+int result;
+if (client.exec(0x1000, &result, 2, 3)) {
+    ...
+}
+```
 
 ## Examples and Tests
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The basic building block is a property. A property has an ID, a parent, a name a
 example:
 
 ```c++
-ThingSetReadWriteProperty<float> voltage = 24 { 0x300, 0, "voltage" };
+ThingSetReadWriteProperty voltage { 0x300, 0, "voltage", 24.0f };
 ```
 
 A property so declared provides its own storage for the given value. Alternatively,
@@ -30,7 +30,7 @@ a property may be declared with a pointer:
 
 ```c++
 float voltage;
-ThingSetReadWriteProperty<float *> voltageProperty(&voltage) { 0x300, 0, "voltage" };
+ThingSetReadWriteProperty voltageProperty { 0x300, 0, "voltage", &voltage };
 ```
 
 Assignment to the property will update the underlying value.
@@ -43,10 +43,10 @@ Structures should be declared thus:
 ```c++
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<float> voltage { 0x601, 0x600, "voltage" };
-    ThingSetReadOnlyProperty<float> current { 0x602, 0x600, "current" };
-    ThingSetReadOnlyProperty<uint64_t> error { 0x603, 0x600, "error" };
-    ThingSetReadOnlyProperty<std::array<float, 6>> cellVoltages { 0x604, 0x600, "cellVoltages" };
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
 };
 ```
 

--- a/examples/asioclient/main.cpp
+++ b/examples/asioclient/main.cpp
@@ -21,22 +21,22 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0 };
 
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 std::array<uint8_t, 1024> rxBuffer;
 std::array<uint8_t, 1024> txBuffer;

--- a/examples/asioserver/main.cpp
+++ b/examples/asioserver/main.cpp
@@ -20,22 +20,22 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 ThingSetUserFunction<0x1000, 0x0, "xDoSomething", int, int, int> doSomething([](auto x, auto y) { return x + y; });
 

--- a/examples/canclient/main.cpp
+++ b/examples/canclient/main.cpp
@@ -41,7 +41,7 @@ struct ModuleRecord
     ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-static inline ThingSetReadOnlyProperty<std::string> nodeId = Eui::getString() { 0x1d, 0, "NodeID" };
+static inline ThingSetReadOnlyProperty nodeId = { 0x1d, 0, "NodeID", Eui::getString() };
 
 ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 

--- a/examples/canclient/main.cpp
+++ b/examples/canclient/main.cpp
@@ -23,27 +23,27 @@ static bool onConfigChange(ThingSetNode *node, ThingSetCallbackReason reason)
 }
 
 ThingSetGroup<0x100, 0x0, "Config"> configGroup(onConfigChange);
-ThingSetReadWriteProperty<0x101, 0x100, "sMinVoltage", float> minVoltage;
-ThingSetReadWriteProperty<0x102, 0x100, "sMaxVoltage", float> maxVoltage;
+ThingSetReadWriteProperty<float> minVoltage { 0x101, 0x100, "sMinVoltage" };
+ThingSetReadWriteProperty<float> maxVoltage { 0x102, 0x100, "sMaxVoltage" };
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x610, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-static inline ThingSetReadOnlyProperty<0x1d, 0, "NodeID", std::string> nodeId = Eui::getString();
+static inline ThingSetReadOnlyProperty<std::string> nodeId = Eui::getString() { 0x1d, 0, "NodeID" };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
 static void test(int argi, float argf)
 {
@@ -54,7 +54,7 @@ ThingSetUserFunction<0x400, 0x0, "xTest", void, int, float> xTestFunc(test);
 // ThingSetParameter<0x401, 0x400, "xTestInt", int> intArg;
 // ThingSetParameter<0x402, 0x400, "xTestFloat", float> floatArg;
 
-ThingSetReadOnlyProperty<0x600, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x600, 0, "Modules" };
 
 std::array<uint8_t, 1024> rxBuffer;
 std::array<uint8_t, 1024> txBuffer;

--- a/examples/canserver/main.cpp
+++ b/examples/canserver/main.cpp
@@ -21,27 +21,27 @@ static bool onConfigChange(ThingSetNode *node, ThingSetCallbackReason reason)
 }
 
 ThingSetGroup<0x100, 0x0, "Config"> configGroup(onConfigChange);
-ThingSetReadWriteProperty<0x101, 0x100, "sMinVoltage", float> minVoltage;
-ThingSetReadWriteProperty<0x102, 0x100, "sMaxVoltage", float> maxVoltage;
+ThingSetReadWriteProperty<float> minVoltage { 0x101, 0x100, "sMinVoltage" };
+ThingSetReadWriteProperty<float> maxVoltage { 0x102, 0x100, "sMaxVoltage" };
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x610, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-static inline ThingSetReadOnlyProperty<0x1d, 0, "NodeID", std::string> nodeId = Eui::getString();
+static inline ThingSetReadOnlyProperty<std::string> nodeId = Eui::getString() { 0x1d, 0, "NodeID" };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
 static void test(int argi, float argf)
 {
@@ -52,7 +52,7 @@ ThingSetUserFunction<0x400, 0x0, "xTest", void, int, float> xTestFunc(test);
 // ThingSetParameter<0x401, 0x400, "xTestInt", int> intArg;
 // ThingSetParameter<0x402, 0x400, "xTestFloat", float> floatArg;
 
-ThingSetReadOnlyProperty<0x600, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x600, 0, "Modules" };
 
 int main()
 {

--- a/examples/canserver/main.cpp
+++ b/examples/canserver/main.cpp
@@ -39,7 +39,7 @@ struct ModuleRecord
     ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-static inline ThingSetReadOnlyProperty<std::string> nodeId = Eui::getString() { 0x1d, 0, "NodeID" };
+static inline ThingSetReadOnlyProperty nodeId = { 0x1d, 0, "NodeID", Eui::getString() };
 
 ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 

--- a/examples/socketclient/main.cpp
+++ b/examples/socketclient/main.cpp
@@ -21,22 +21,22 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 std::array<uint8_t, 1024> rxBuffer;
 std::array<uint8_t, 1024> txBuffer;

--- a/examples/socketserver/main.cpp
+++ b/examples/socketserver/main.cpp
@@ -20,22 +20,22 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 ThingSetUserFunction<0x1000, 0x0, "xDoSomething", int, int, int> doSomething([](auto x, auto y) { return x + y; });
 

--- a/examples/zephyrcanclient/main.cpp
+++ b/examples/zephyrcanclient/main.cpp
@@ -24,22 +24,22 @@ ThingSetZephyrCanSubscriptionTransport subscriptionTransport(interface);
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x610, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadOnlyProperty<0x600, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x600, 0, "Modules" };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
 ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; });
 

--- a/examples/zephyrcanserver/main.cpp
+++ b/examples/zephyrcanserver/main.cpp
@@ -20,22 +20,22 @@ ThingSetZephyrCanServerTransport transport(interface, rxBuffer, txBuffer);
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x610, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadOnlyProperty<0x600, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x600, 0, "Modules" };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
 ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; });
 

--- a/examples/zephyripclient/src/main.cpp
+++ b/examples/zephyripclient/src/main.cpp
@@ -22,23 +22,21 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>>
-        supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
-
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 std::array<uint8_t, 1024> rxBuffer;
 std::array<uint8_t, 1024> txBuffer;

--- a/examples/zephyripserver/src/main.cpp
+++ b/examples/zephyripserver/src/main.cpp
@@ -19,23 +19,22 @@ ThingSetGroup<0x610, 0x610, "Supercells"> supercells;
 
 struct SupercellRecord
 {
-    ThingSetReadWriteProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadWriteProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadWriteRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadWriteRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
-    ThingSetReadWriteProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadWriteProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadWriteProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadWriteProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadWriteProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>>
-        supercells;
+    ThingSetReadWriteRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadWriteRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadWriteRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadWriteRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadWriteRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
-ThingSetReadWriteProperty<0x620, 0x0, "Modules", std::array<ModuleRecord, 2>> moduleRecords;
+ThingSetReadWriteProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x620, 0x0, "Modules" };
 
 ThingSetUserFunction<0x1000, 0x0, "xDoSomething", int, int, int> doSomething([](auto x, auto y) {
     return x + y;

--- a/include/thingset++/IdentifiableThingSetNode.hpp
+++ b/include/thingset++/IdentifiableThingSetNode.hpp
@@ -14,6 +14,7 @@ namespace ThingSet {
 template <typename T>
 concept NodeBase = std::is_base_of_v<ThingSetNode, T>;
 
+/// @brief Represents a ThingSet node with an ID.
 template <NodeBase Base>
 class _IdentifiableThingSetNode : public Base
 {
@@ -22,8 +23,15 @@ protected:
     const unsigned _parentId;
     const std::string_view _name;
 
-    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : Base(), _id(id), _parentId(parentId), _name(name)
-    {}
+    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : ThingSetNode(), _id(id), _parentId(parentId), _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
+    ~_IdentifiableThingSetNode()
+    {
+        ThingSetRegistry::unregisterNode(this);
+    }
 
 public:
     const std::string_view getName() const override
@@ -42,33 +50,39 @@ public:
     }
 };
 
-/// @brief Represents a ThingSet node with an ID.
-class IdentifiableThingSetNode : public _IdentifiableThingSetNode<ThingSetNode>
-{
-protected:
-    IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : _IdentifiableThingSetNode<ThingSetNode>(id, parentId, name)
-    {
-        ThingSetRegistry::registerNode(this);
-    }
-
-    ~IdentifiableThingSetNode()
-    {
-        ThingSetRegistry::unregisterNode(this);
-    }
-};
-
 /// @brief Represents a ThingSet node with an ID and which may have one or more child nodes.
-class IdentifiableThingSetParentNode : public _IdentifiableThingSetNode<ThingSetParentNode>
+template <>
+class _IdentifiableThingSetNode<ThingSetParentNode> : public ThingSetParentNode
 {
 protected:
-    IdentifiableThingSetParentNode(const unsigned id, const unsigned parentId, const std::string_view name) : _IdentifiableThingSetNode<ThingSetParentNode>(id, parentId, name)
+    const unsigned _id;
+    const unsigned _parentId;
+    const std::string_view _name;
+
+    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : ThingSetParentNode(), _id(id), _parentId(parentId), _name(name)
     {
         ThingSetRegistry::registerNode(this);
     }
 
-    ~IdentifiableThingSetParentNode()
+    ~_IdentifiableThingSetNode()
     {
         ThingSetRegistry::unregisterNode(this);
+    }
+
+public:
+    const std::string_view getName() const override
+    {
+        return _name;
+    }
+
+    unsigned getId() const override
+    {
+        return _id;
+    }
+
+    unsigned getParentId() const override
+    {
+        return _parentId;
     }
 
     bool tryCastTo(ThingSetNodeType type, void **target) override
@@ -82,5 +96,8 @@ protected:
         }
     }
 };
+
+using IdentifiableThingSetNode = _IdentifiableThingSetNode<ThingSetNode>;
+using IdentifiableThingSetParentNode = _IdentifiableThingSetNode<ThingSetParentNode>;
 
 } // namespace ThingSet

--- a/include/thingset++/IdentifiableThingSetNode.hpp
+++ b/include/thingset++/IdentifiableThingSetNode.hpp
@@ -14,42 +14,39 @@ namespace ThingSet {
 template <typename T>
 concept NodeBase = std::is_base_of_v<ThingSetNode, T>;
 
-template <NodeBase Base, unsigned Id, unsigned ParentId, StringLiteral Name>
+template <NodeBase Base>
 class _IdentifiableThingSetNode : public Base
 {
 protected:
-    _IdentifiableThingSetNode() : Base()
+    const unsigned _id;
+    const unsigned _parentId;
+    const std::string_view _name;
+
+    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : Base(), _id(id), _parentId(parentId), _name(name)
     {}
 
 public:
-    constexpr const std::string_view getName() const override
+    const std::string_view getName() const override
     {
-        return Name.string_view();
+        return _name;
     }
 
-    constexpr unsigned getId() const override
+    unsigned getId() const override
     {
-        return Id;
+        return _id;
     }
 
-    constexpr unsigned getParentId() const override
+    unsigned getParentId() const override
     {
-        return ParentId;
+        return _parentId;
     }
-
-    constexpr static const unsigned id = Id;
-    constexpr static const std::string_view &name = Name.string_view();
 };
 
 /// @brief Represents a ThingSet node with an ID.
-/// @tparam Id The unique integer ID of the ThingSet node.
-/// @tparam ParentId The integer ID of the parent node.
-/// @tparam Name The name of the node.
-template <unsigned Id, unsigned ParentId, StringLiteral Name>
-class IdentifiableThingSetNode : public _IdentifiableThingSetNode<ThingSetNode, Id, ParentId, Name>
+class IdentifiableThingSetNode : public _IdentifiableThingSetNode<ThingSetNode>
 {
 protected:
-    constexpr IdentifiableThingSetNode() : _IdentifiableThingSetNode<ThingSetNode, Id, ParentId, Name>()
+    IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : _IdentifiableThingSetNode<ThingSetNode>(id, parentId, name)
     {
         ThingSetRegistry::registerNode(this);
     }
@@ -61,14 +58,10 @@ protected:
 };
 
 /// @brief Represents a ThingSet node with an ID and which may have one or more child nodes.
-/// @tparam Id The unique integer ID of the ThingSet node.
-/// @tparam ParentId The integer ID of the parent node.
-/// @tparam Name The name of the node.
-template <unsigned Id, unsigned ParentId, StringLiteral Name>
-class IdentifiableThingSetParentNode : public _IdentifiableThingSetNode<ThingSetParentNode, Id, ParentId, Name>
+class IdentifiableThingSetParentNode : public _IdentifiableThingSetNode<ThingSetParentNode>
 {
 protected:
-    constexpr IdentifiableThingSetParentNode() : _IdentifiableThingSetNode<ThingSetParentNode, Id, ParentId, Name>()
+    IdentifiableThingSetParentNode(const unsigned id, const unsigned parentId, const std::string_view name) : _IdentifiableThingSetNode<ThingSetParentNode>(id, parentId, name)
     {
         ThingSetRegistry::registerNode(this);
     }

--- a/include/thingset++/IdentifiableThingSetNode.hpp
+++ b/include/thingset++/IdentifiableThingSetNode.hpp
@@ -39,12 +39,12 @@ public:
         return _name;
     }
 
-    unsigned getId() const override
+    uint16_t getId() const override
     {
         return _id;
     }
 
-    unsigned getParentId() const override
+    uint16_t getParentId() const override
     {
         return _parentId;
     }
@@ -75,12 +75,12 @@ public:
         return _name;
     }
 
-    unsigned getId() const override
+    uint16_t getId() const override
     {
         return _id;
     }
 
-    unsigned getParentId() const override
+    uint16_t getParentId() const override
     {
         return _parentId;
     }

--- a/include/thingset++/IdentifiableThingSetNode.hpp
+++ b/include/thingset++/IdentifiableThingSetNode.hpp
@@ -19,11 +19,11 @@ template <NodeBase Base>
 class _IdentifiableThingSetNode : public Base
 {
 protected:
-    const unsigned _id;
-    const unsigned _parentId;
+    const uint16_t _id;
+    const uint16_t _parentId;
     const std::string_view _name;
 
-    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : ThingSetNode(), _id(id), _parentId(parentId), _name(name)
+    _IdentifiableThingSetNode(const uint16_t id, const uint16_t parentId, const std::string_view name) : ThingSetNode(), _id(id), _parentId(parentId), _name(name)
     {
         ThingSetRegistry::registerNode(this);
     }
@@ -55,11 +55,11 @@ template <>
 class _IdentifiableThingSetNode<ThingSetParentNode> : public ThingSetParentNode
 {
 protected:
-    const unsigned _id;
-    const unsigned _parentId;
+    const uint16_t _id;
+    const uint16_t _parentId;
     const std::string_view _name;
 
-    _IdentifiableThingSetNode(const unsigned id, const unsigned parentId, const std::string_view name) : ThingSetParentNode(), _id(id), _parentId(parentId), _name(name)
+    _IdentifiableThingSetNode(const uint16_t id, const uint16_t parentId, const std::string_view name) : ThingSetParentNode(), _id(id), _parentId(parentId), _name(name)
     {
         ThingSetRegistry::registerNode(this);
     }

--- a/include/thingset++/IdentifiableThingSetNode.hpp
+++ b/include/thingset++/IdentifiableThingSetNode.hpp
@@ -15,15 +15,11 @@ template <typename T>
 concept NodeBase = std::is_base_of_v<ThingSetNode, T>;
 
 /// @brief Represents a ThingSet node with an ID.
-template <NodeBase Base>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, NodeBase Base>
 class _IdentifiableThingSetNode : public Base
 {
 protected:
-    const uint16_t _id;
-    const uint16_t _parentId;
-    const std::string_view _name;
-
-    _IdentifiableThingSetNode(const uint16_t id, const uint16_t parentId, const std::string_view name) : ThingSetNode(), _id(id), _parentId(parentId), _name(name)
+    _IdentifiableThingSetNode() : ThingSetNode()
     {
         ThingSetRegistry::registerNode(this);
     }
@@ -36,30 +32,26 @@ protected:
 public:
     const std::string_view getName() const override
     {
-        return _name;
+        return Name.string_view();
     }
 
     uint16_t getId() const override
     {
-        return _id;
+        return Id;
     }
 
     uint16_t getParentId() const override
     {
-        return _parentId;
+        return ParentId;
     }
 };
 
 /// @brief Represents a ThingSet node with an ID and which may have one or more child nodes.
-template <>
-class _IdentifiableThingSetNode<ThingSetParentNode> : public ThingSetParentNode
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
+class _IdentifiableThingSetNode<Id, ParentId, Name, ThingSetParentNode> : public ThingSetParentNode
 {
 protected:
-    const uint16_t _id;
-    const uint16_t _parentId;
-    const std::string_view _name;
-
-    _IdentifiableThingSetNode(const uint16_t id, const uint16_t parentId, const std::string_view name) : ThingSetParentNode(), _id(id), _parentId(parentId), _name(name)
+    _IdentifiableThingSetNode() : ThingSetParentNode()
     {
         ThingSetRegistry::registerNode(this);
     }
@@ -72,17 +64,17 @@ protected:
 public:
     const std::string_view getName() const override
     {
-        return _name;
+        return Name.string_view();
     }
 
     uint16_t getId() const override
     {
-        return _id;
+        return Id;
     }
 
     uint16_t getParentId() const override
     {
-        return _parentId;
+        return ParentId;
     }
 
     bool tryCastTo(ThingSetNodeType type, void **target) override
@@ -97,7 +89,9 @@ public:
     }
 };
 
-using IdentifiableThingSetNode = _IdentifiableThingSetNode<ThingSetNode>;
-using IdentifiableThingSetParentNode = _IdentifiableThingSetNode<ThingSetParentNode>;
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
+using IdentifiableThingSetNode = _IdentifiableThingSetNode<Id, ParentId, Name, ThingSetNode>;
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
+using IdentifiableThingSetParentNode = _IdentifiableThingSetNode<Id, ParentId, Name, ThingSetParentNode>;
 
 } // namespace ThingSet

--- a/include/thingset++/ThingSet.hpp
+++ b/include/thingset++/ThingSet.hpp
@@ -7,6 +7,7 @@
 #include "thingset++/ThingSetFunction.hpp"
 #include "thingset++/ThingSetGroup.hpp"
 #include "thingset++/ThingSetProperty.hpp"
+#include "thingset++/ThingSetRecordMember.hpp"
 
 #ifdef __ZEPHYR__
 #ifdef CONFIG_THINGSET_PLUS_PLUS_SERVER

--- a/include/thingset++/ThingSetAccess.hpp
+++ b/include/thingset++/ThingSetAccess.hpp
@@ -6,11 +6,12 @@
 #pragma once
 
 #include <type_traits>
+#include <cstdint>
 
 namespace ThingSet {
 
 /// @brief Specifies ThingSet access controls.
-enum ThingSetAccess
+enum struct ThingSetAccess : uint8_t
 {
     userRead = 1 << 0,
     expertRead = 1 << 1,
@@ -26,13 +27,19 @@ enum ThingSetAccess
     anyReadWrite = anyRead | anyWrite,
 };
 
-constexpr inline ThingSetAccess operator|(ThingSetAccess lhs, ThingSetAccess rhs)
+constexpr inline ThingSetAccess operator&(const ThingSetAccess &lhs, const ThingSetAccess &rhs)
+{
+    using T = std::underlying_type_t<ThingSetAccess>;
+    return static_cast<ThingSetAccess>(static_cast<T>(lhs) & static_cast<T>(rhs));
+}
+
+constexpr inline ThingSetAccess operator|(const ThingSetAccess &lhs, const ThingSetAccess &rhs)
 {
     using T = std::underlying_type_t<ThingSetAccess>;
     return static_cast<ThingSetAccess>(static_cast<T>(lhs) | static_cast<T>(rhs));
 }
 
-constexpr inline ThingSetAccess &operator|=(ThingSetAccess &lhs, ThingSetAccess &rhs)
+constexpr inline ThingSetAccess &operator|=(ThingSetAccess &lhs, const ThingSetAccess &rhs)
 {
     lhs = lhs | rhs;
     return lhs;

--- a/include/thingset++/ThingSetAccess.hpp
+++ b/include/thingset++/ThingSetAccess.hpp
@@ -13,6 +13,7 @@ namespace ThingSet {
 /// @brief Specifies ThingSet access controls.
 enum struct ThingSetAccess : uint8_t
 {
+    none = 0,
     userRead = 1 << 0,
     expertRead = 1 << 1,
     manufacturerRead = 1 << 2,

--- a/include/thingset++/ThingSetClient.hpp
+++ b/include/thingset++/ThingSetClient.hpp
@@ -68,6 +68,16 @@ public:
         return doRequest(id, ThingSetBinaryRequestType::get, [](auto) { return true; }, &result);
     }
 
+    /// @brief Gets a value.
+    /// @tparam T The type of the value to get.
+    /// @param id The string identifier of the value.
+    /// @param result A reference to a variable which will hold the retrieved value.
+    /// @return True if retrieval succeeded, otherwise false.
+    template <typename T> bool get(const std::string &id, T &result)
+    {
+        return doRequest(id, ThingSetBinaryRequestType::get, [](auto) { return true; }, &result);
+    }
+
     template <typename T> bool update(const std::string &fullyQualifiedName, const T &value)
     {
         size_t index = fullyQualifiedName.find_last_of('/');
@@ -89,7 +99,9 @@ private:
     /// @param encode A function to encode any additional data in a request.
     /// @param result A pointer to a variable which will contain the decoded result, if any. Pass null if no result is expected.
     /// @return True if invocation succeeded, otherwise false.
-    template <typename Id, typename T> bool doRequest(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode, T *result)
+    template <typename Id, typename T>
+        requires std::is_integral_v<Id> or std::is_convertible_v<Id, std::string_view>
+    bool doRequest(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode, T *result)
     {
         uint8_t *responseBuffer;
         size_t responseSize;
@@ -101,14 +113,18 @@ private:
         return false;
     }
 
-    template <typename Id> bool doRequest(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode)
+    template <typename Id>
+        requires std::is_integral_v<Id> or std::is_convertible_v<Id, std::string_view>
+    bool doRequest(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode)
     {
         uint8_t *responseBuffer;
         size_t responseSize;
         return doRequestCore(id, type, encode, &responseBuffer, responseSize);
     }
 
-    template <typename Id> bool doRequestCore(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode, uint8_t **responseBuffer, size_t &responseSize)
+    template <typename Id>
+        requires std::is_integral_v<Id> or std::is_convertible_v<Id, std::string_view>
+    bool doRequestCore(const Id &id, ThingSetBinaryRequestType type, std::function<bool (ThingSetBinaryEncoder*)> encode, uint8_t **responseBuffer, size_t &responseSize)
     {
         _txBuffer[0] = (uint8_t)type;
         FixedDepthThingSetBinaryEncoder encoder(_txBuffer + 1, _txBufferSize - 1);

--- a/include/thingset++/ThingSetCompatibility.hpp
+++ b/include/thingset++/ThingSetCompatibility.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Brill Power.
+ * Copyright (c) The ThingSet Project Contributors.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/thingset++/ThingSetCompatibility.hpp
+++ b/include/thingset++/ThingSetCompatibility.hpp
@@ -86,9 +86,9 @@ template <typename T> struct __ArrayHolder {
 /// @tparam Access The access permissions for this property.
 struct __PropertyBuilder
 {
-    template <typename T>
-    static ThingSetProperty<T*> build(const unsigned id, const unsigned parentId, const std::string name, ThingSetAccess access, T* value) {
-        return ThingSetProperty<T*>(id, parentId, name, access, value);
+    template <ThingSetAccess Access, uint32_t Subset, typename T>
+    static ThingSetProperty<T*, Access, uint32_t, Subset> build(const unsigned id, const unsigned parentId, const std::string name, T* value) {
+        return ThingSetProperty<T*, Access, uint32_t, Subset>(id, parentId, name, value);
     }
 };
 
@@ -98,7 +98,7 @@ struct __PropertyBuilder
     ThingSet::ThingSetGroup<id, parentId, name> thingset_##id;
 
 #define THINGSET_ADD_ITEM(parentId, id, name, pointer, access, subsets, type)                                          \
-    auto thingset_##id = ThingSet::__PropertyBuilder::build(id, parentId, name, ThingSet::convertAccess<access>::value, pointer);
+    auto thingset_##id = ThingSet::__PropertyBuilder::build<ThingSet::convertAccess<access>::value, subsets>(id, parentId, name, pointer);
 
 #define THINGSET_ADD_ITEM_BOOL(parentId, id, name, pointer, access, subsets)                                           \
     THINGSET_ADD_ITEM(parentId, id, name, pointer, access, subsets, bool)
@@ -137,6 +137,6 @@ struct __PropertyBuilder
     ThingSet::__ArrayHolder<float> variableName = { .array = arr, .maxElements = sizeof(arr), .numElements = usedElements };
 
 #define THINGSET_ADD_ITEM_ARRAY(parentId, id, name, arrayHolder, access, subsets) \
-    auto thingset_##id = ThingSet::__PropertyBuilder::build(id, parentId, name, ThingSet::convertAccess<access>::value, arrayHolder.array);
+    auto thingset_##id = ThingSet::__PropertyBuilder::build<ThingSet::convertAccess<access>::value, subsets>(id, parentId, name, arrayHolder.array);
 
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))

--- a/include/thingset++/ThingSetCompatibility.hpp
+++ b/include/thingset++/ThingSetCompatibility.hpp
@@ -84,11 +84,11 @@ template <typename T> struct __ArrayHolder {
 /// @tparam ParentId The ID of the parent container.
 /// @tparam Name The name of the property.
 /// @tparam Access The access permissions for this property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access> struct __PropertyBuilder
+struct __PropertyBuilder
 {
     template <typename T>
-    static ThingSetProperty<Id, ParentId, Name, Access, T*> build(T** value) {
-        return ThingSetProperty<Id, ParentId, Name, Access, T*>(*value);
+    static ThingSetProperty<T*> build(const unsigned id, const unsigned parentId, const std::string name, ThingSetAccess access, T* value) {
+        return ThingSetProperty<T*>(id, parentId, name, access, value);
     }
 };
 
@@ -98,7 +98,7 @@ template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Acc
     ThingSet::ThingSetGroup<id, parentId, name> thingset_##id;
 
 #define THINGSET_ADD_ITEM(parentId, id, name, pointer, access, subsets, type)                                          \
-    ThingSet::ThingSetProperty<id, parentId, name, ThingSet::convertAccess<access>::value, type *> thingset_##id(pointer);
+    auto thingset_##id = ThingSet::__PropertyBuilder::build(id, parentId, name, ThingSet::convertAccess<access>::value, pointer);
 
 #define THINGSET_ADD_ITEM_BOOL(parentId, id, name, pointer, access, subsets)                                           \
     THINGSET_ADD_ITEM(parentId, id, name, pointer, access, subsets, bool)
@@ -137,6 +137,6 @@ template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Acc
     ThingSet::__ArrayHolder<float> variableName = { .array = arr, .maxElements = sizeof(arr), .numElements = usedElements };
 
 #define THINGSET_ADD_ITEM_ARRAY(parentId, id, name, arrayHolder, access, subsets) \
-    auto thingset_##id = ThingSet::__PropertyBuilder<parentId, id, name, ThingSet::convertAccess<access>::value>::build(arrayHolder.array);
+    auto thingset_##id = ThingSet::__PropertyBuilder::build(id, parentId, name, ThingSet::convertAccess<access>::value, arrayHolder.array);
 
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))

--- a/include/thingset++/ThingSetFunction.hpp
+++ b/include/thingset++/ThingSetFunction.hpp
@@ -45,15 +45,15 @@ static bool invoke(std::function<void(Args...)> &function, std::tuple<Args...> &
 /// @tparam Access Access control flags.
 /// @tparam Result The return type of the function.
 /// @tparam ...Args The argument types of the function, if any.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename Result, typename... Args>
-class ThingSetFunction : public IdentifiableThingSetParentNode, public ThingSetInvocable
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename Result, typename... Args>
+class ThingSetFunction : public IdentifiableThingSetParentNode<Id, ParentId, Name>, public ThingSetInvocable
 {
 private:
-    template <unsigned ChildId, StringLiteral ArgName, typename T>
-    class ThingSetFunctionParameter : public IdentifiableThingSetNode
+    template <uint16_t ChildId, StringLiteral ArgName, typename T>
+    class ThingSetFunctionParameter : public IdentifiableThingSetNode<ChildId, Id, ArgName>
     {
     public:
-        ThingSetFunctionParameter() : IdentifiableThingSetNode(ChildId, Id, ArgName.string_view())
+        ThingSetFunctionParameter() : IdentifiableThingSetNode<ChildId, Id, ArgName>()
         {}
 
         const std::string getType() const override
@@ -94,7 +94,7 @@ private:
 
 public:
     ThingSetFunction(std::function<Result(Args...)> function)
-        : IdentifiableThingSetParentNode(Id, ParentId, Name.string_view()), _function(function)
+        : IdentifiableThingSetParentNode<Id, ParentId, Name>(), _function(function)
     {}
 
     constexpr const std::string getType() const override
@@ -132,13 +132,13 @@ public:
     }
 };
 
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename Result, typename... Args>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename Result, typename... Args>
 using ThingSetUserFunction = ThingSetFunction<Id, ParentId, Name, ThingSetAccess::anyWrite, Result, Args...>;
 
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename Result, typename... Args>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename Result, typename... Args>
 using ThingSetAdvancedFunction = ThingSetFunction<Id, ParentId, Name, ThingSetAccess::expertWrite, Result, Args...>;
 
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename Result, typename... Args>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename Result, typename... Args>
 using ThingSetManufacturerFunction =
     ThingSetFunction<Id, ParentId, Name, ThingSetAccess::manufacturerWrite, Result, Args...>;
 

--- a/include/thingset++/ThingSetFunction.hpp
+++ b/include/thingset++/ThingSetFunction.hpp
@@ -46,12 +46,16 @@ static bool invoke(std::function<void(Args...)> &function, std::tuple<Args...> &
 /// @tparam Result The return type of the function.
 /// @tparam ...Args The argument types of the function, if any.
 template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename Result, typename... Args>
-class ThingSetFunction : public IdentifiableThingSetParentNode<Id, ParentId, Name>, public ThingSetInvocable
+class ThingSetFunction : public IdentifiableThingSetParentNode, public ThingSetInvocable
 {
 private:
     template <unsigned ChildId, StringLiteral ArgName, typename T>
-    class ThingSetFunctionParameter : public IdentifiableThingSetNode<ChildId, Id, ArgName>
+    class ThingSetFunctionParameter : public IdentifiableThingSetNode
     {
+    public:
+        ThingSetFunctionParameter() : IdentifiableThingSetNode(ChildId, Id, ArgName.string_view())
+        {}
+
         const std::string getType() const override
         {
             return ThingSetType<T>::name.str();
@@ -100,7 +104,7 @@ private:
 
 public:
     ThingSetFunction(std::function<Result(Args...)> function)
-        : IdentifiableThingSetParentNode<Id, ParentId, Name>::IdentifiableThingSetParentNode(), _function(function)
+        : IdentifiableThingSetParentNode(Id, ParentId, Name.string_view()), _function(function)
     {}
 
     constexpr const std::string getType() const override

--- a/include/thingset++/ThingSetFunction.hpp
+++ b/include/thingset++/ThingSetFunction.hpp
@@ -61,19 +61,9 @@ private:
             return ThingSetType<T>::name.str();
         }
 
-        constexpr ThingSetNodeType getNodeType() const override
-        {
-            return ThingSetNodeType::parameter;
-        }
-
         constexpr ThingSetAccess getAccess() const override
         {
             return ThingSetAccess::anyReadWrite;
-        }
-
-        bool checkAccess(ThingSetAccess) const override
-        {
-            return true;
         }
     };
 
@@ -112,11 +102,6 @@ public:
         return ThingSetType<std::function<Result(Args...)>>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::function;
-    }
-
     bool invoke(ThingSetDecoder &decoder, ThingSetEncoder &encoder) override
     {
         return decoder.decodeList(_arguments) && ThingSet::invoke(_function, _arguments, encoder);
@@ -139,11 +124,6 @@ public:
     constexpr ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (access & Access) == Access;
     }
 
     bool invokeCallback(ThingSetNode *, ThingSetCallbackReason) const override

--- a/include/thingset++/ThingSetGroup.hpp
+++ b/include/thingset++/ThingSetGroup.hpp
@@ -17,7 +17,7 @@ static inline bool defaultCallback(ThingSetNode *, ThingSetCallbackReason)
 }
 
 template <unsigned Id, unsigned ParentId, StringLiteral Name>
-class ThingSetGroup : public IdentifiableThingSetParentNode<Id, ParentId, Name>
+class ThingSetGroup : public IdentifiableThingSetParentNode
 {
 private:
     std::function<bool(ThingSetNode *, ThingSetCallbackReason)> _callback;
@@ -25,7 +25,7 @@ private:
 public:
     ThingSetGroup() : ThingSetGroup(defaultCallback){};
     ThingSetGroup(std::function<bool(ThingSetNode *, ThingSetCallbackReason)> callback)
-        : IdentifiableThingSetParentNode<Id, ParentId, Name>(), _callback(callback){};
+        : IdentifiableThingSetParentNode(Id, ParentId, Name.string_view()), _callback(callback){};
 
     constexpr const std::string getType() const override
     {

--- a/include/thingset++/ThingSetGroup.hpp
+++ b/include/thingset++/ThingSetGroup.hpp
@@ -32,17 +32,6 @@ public:
         return "group";
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::group;
-    }
-
-    bool checkAccess(ThingSetAccess) const override
-    {
-        // no access control on groups at the moment
-        return true;
-    }
-
     constexpr ThingSetAccess getAccess() const override
     {
         return ThingSetAccess::anyRead;

--- a/include/thingset++/ThingSetGroup.hpp
+++ b/include/thingset++/ThingSetGroup.hpp
@@ -16,8 +16,8 @@ static inline bool defaultCallback(ThingSetNode *, ThingSetCallbackReason)
     return true;
 }
 
-template <unsigned Id, unsigned ParentId, StringLiteral Name>
-class ThingSetGroup : public IdentifiableThingSetParentNode
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
+class ThingSetGroup : public IdentifiableThingSetParentNode<Id, ParentId, Name>
 {
 private:
     std::function<bool(ThingSetNode *, ThingSetCallbackReason)> _callback;
@@ -25,7 +25,7 @@ private:
 public:
     ThingSetGroup() : ThingSetGroup(defaultCallback){};
     ThingSetGroup(std::function<bool(ThingSetNode *, ThingSetCallbackReason)> callback)
-        : IdentifiableThingSetParentNode(Id, ParentId, Name.string_view()), _callback(callback){};
+        : IdentifiableThingSetParentNode<Id, ParentId, Name>(), _callback(callback){};
 
     constexpr const std::string getType() const override
     {

--- a/include/thingset++/ThingSetNode.hpp
+++ b/include/thingset++/ThingSetNode.hpp
@@ -39,13 +39,9 @@ public:
 
     constexpr virtual const std::string getType() const = 0;
 
-    constexpr virtual ThingSetNodeType getNodeType() const = 0;
-
     virtual bool tryCastTo(ThingSetNodeType type, void **target);
 
     constexpr virtual ThingSetAccess getAccess() const = 0;
-
-    virtual bool checkAccess(ThingSetAccess access) const = 0;
 
     constexpr virtual uint32_t getSubsets() const
     {

--- a/include/thingset++/ThingSetNode.hpp
+++ b/include/thingset++/ThingSetNode.hpp
@@ -33,9 +33,9 @@ public:
 
     constexpr virtual const std::string_view getName() const = 0;
 
-    constexpr virtual unsigned getId() const = 0;
+    constexpr virtual uint16_t getId() const = 0;
 
-    constexpr virtual unsigned getParentId() const = 0;
+    constexpr virtual uint16_t getParentId() const = 0;
 
     constexpr virtual const std::string getType() const = 0;
 

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -31,21 +31,57 @@ static constexpr Subset operator|(const Subset &lhs, const Subset &rhs)
 /// @tparam T Type of value.
 /// @tparam NodeBase Ultimate base class.
 /// @tparam Base Intermediate base class.
-template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0, NodeBase NodeBase = ThingSetNode, IdentifiableBase<NodeBase> Base = IdentifiableThingSetNode>
+template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0, NodeBase Base = ThingSetNode>
           requires std::is_enum_v<SubsetType>
 class ThingSetProperty : public ThingSetValue<T>, public Base
 {
+private:
+    const uint16_t _id;
+    const uint16_t _parentId;
+    const std::string_view _name;
+
 public:
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name) :
         ThingSetValue<T>(),
-        Base(id, parentId, name)
-    {}
+        Base(),
+        _id(id),
+        _parentId(parentId),
+        _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, const T &value) :
         ThingSetValue<T>(value),
-        Base(id, parentId, name)
-    {}
+        Base(),
+        _id(id),
+        _parentId(parentId),
+        _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
+    ~ThingSetProperty()
+    {
+        ThingSetRegistry::unregisterNode(this);
+    }
 
     using ThingSetValue<T>::operator=;
+
+    const std::string_view getName() const override
+    {
+        return _name;
+    }
+
+    unsigned getId() const override
+    {
+        return _id;
+    }
+
+    unsigned getParentId() const override
+    {
+        return _parentId;
+    }
 
     constexpr const std::string getType() const override
     {
@@ -89,14 +125,44 @@ public:
 
 /// @brief Partial specialisation of ThingSetProperty for pointers to values.
 template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset> requires std::is_enum_v<SubsetType>
-class ThingSetProperty<T *, Access, SubsetType, Subset, ThingSetNode, IdentifiableThingSetNode>
-    : public ThingSetValue<T *>, public IdentifiableThingSetNode
+class ThingSetProperty<T *, Access, SubsetType, Subset, ThingSetNode>
+    : public ThingSetValue<T *>, public ThingSetNode
 {
+private:
+    const uint16_t _id;
+    const uint16_t _parentId;
+    const std::string_view _name;
+
 public:
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, T *value) :
         ThingSetValue<T *>(value),
-        IdentifiableThingSetNode(id, parentId, name)
-    {}
+        ThingSetNode(),
+        _id(id),
+        _parentId(parentId),
+        _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
+    ~ThingSetProperty()
+    {
+        ThingSetRegistry::unregisterNode(this);
+    }
+
+    const std::string_view getName() const override
+    {
+        return _name;
+    }
+
+    unsigned getId() const override
+    {
+        return _id;
+    }
+
+    unsigned getParentId() const override
+    {
+        return _parentId;
+    }
 
     constexpr const std::string getType() const override
     {
@@ -153,21 +219,57 @@ public:
 /// @brief Partial specialisation of ThingSetProperty for record arrays.
 template <typename Element, std::size_t Size, ThingSetAccess Access, typename SubsetType, SubsetType Subset>
     requires std::is_class_v<Element>
-class ThingSetProperty<std::array<Element, Size>, Access, SubsetType, Subset, ThingSetParentNode, IdentifiableThingSetParentNode>
-    : public ThingSetValue<std::array<Element, Size>>, public IdentifiableThingSetParentNode,
+class ThingSetProperty<std::array<Element, Size>, Access, SubsetType, Subset, ThingSetParentNode>
+    : public ThingSetValue<std::array<Element, Size>>, public ThingSetParentNode,
       public ThingSetCustomRequestHandler
 {
+private:
+    const uint16_t _id;
+    const uint16_t _parentId;
+    const std::string_view _name;
+
 public:
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name) :
         ThingSetValue<std::array<Element, Size>>(),
-        IdentifiableThingSetParentNode(id, parentId, name)
-    {}
+        ThingSetParentNode(),
+        _id(id),
+        _parentId(parentId),
+        _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, const std::array<Element, Size> &value) :
         ThingSetValue<std::array<Element, Size>>(value),
-        IdentifiableThingSetParentNode(id, parentId, name)
-    {}
+        ThingSetParentNode(),
+        _id(id),
+        _parentId(parentId),
+        _name(name)
+    {
+        ThingSetRegistry::registerNode(this);
+    }
+
+    ~ThingSetProperty()
+    {
+        ThingSetRegistry::unregisterNode(this);
+    }
 
     using ThingSetValue<std::array<Element, Size>>::operator=;
+
+    const std::string_view getName() const override
+    {
+        return _name;
+    }
+
+    unsigned getId() const override
+    {
+        return _id;
+    }
+
+    unsigned getParentId() const override
+    {
+        return _parentId;
+    }
 
     ThingSetParentNode::ChildIterator begin() override
     {

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -113,12 +113,12 @@ public:
         return _name;
     }
 
-    unsigned getId() const override
+    uint16_t getId() const override
     {
         return _id;
     }
 
-    unsigned getParentId() const override
+    uint16_t getParentId() const override
     {
         return _parentId;
     }
@@ -185,12 +185,12 @@ public:
         return _name;
     }
 
-    unsigned getId() const override
+    uint16_t getId() const override
     {
         return _id;
     }
 
-    unsigned getParentId() const override
+    uint16_t getParentId() const override
     {
         return _parentId;
     }
@@ -282,12 +282,12 @@ public:
         return _name;
     }
 
-    unsigned getId() const override
+    uint16_t getId() const override
     {
         return _id;
     }
 
-    unsigned getParentId() const override
+    uint16_t getParentId() const override
     {
         return _parentId;
     }

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -31,26 +31,18 @@ static constexpr Subset operator|(const Subset &lhs, const Subset &rhs)
 /// @tparam T Type of value.
 /// @tparam NodeBase Ultimate base class.
 /// @tparam Base Intermediate base class.
-template <typename T, typename SubsetType = Subset, NodeBase NodeBase = ThingSetNode, IdentifiableBase<NodeBase> Base = IdentifiableThingSetNode>
+template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0, NodeBase NodeBase = ThingSetNode, IdentifiableBase<NodeBase> Base = IdentifiableThingSetNode>
           requires std::is_enum_v<SubsetType>
 class ThingSetProperty : public ThingSetValue<T>, public Base
 {
-private:
-    const ThingSetAccess _access;
-    const SubsetType _subset;
-
 public:
-    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name) :
         ThingSetValue<T>(),
-        Base(id, parentId, name),
-        _access(access),
-        _subset(subset)
+        Base(id, parentId, name)
     {}
-    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, const T &value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, const T &value) :
         ThingSetValue<T>(value),
-        Base(id, parentId, name),
-        _access(access),
-        _subset(subset)
+        Base(id, parentId, name)
     {}
 
     using ThingSetValue<T>::operator=;
@@ -81,35 +73,29 @@ public:
 
     uint32_t getSubsets() const override
     {
-        return (uint32_t)_subset;
+        return (uint32_t)Subset;
     }
 
     ThingSetAccess getAccess() const override
     {
-        return _access;
+        return Access;
     }
 
     bool checkAccess(ThingSetAccess access) const override
     {
-        return (_access & access) == access;
+        return (Access & access) == access;
     }
 };
 
 /// @brief Partial specialisation of ThingSetProperty for pointers to values.
-template <typename T, typename SubsetType> requires std::is_enum_v<SubsetType>
-class ThingSetProperty<T *, SubsetType, ThingSetNode, IdentifiableThingSetNode>
+template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset> requires std::is_enum_v<SubsetType>
+class ThingSetProperty<T *, Access, SubsetType, Subset, ThingSetNode, IdentifiableThingSetNode>
     : public ThingSetValue<T *>, public IdentifiableThingSetNode
 {
-private:
-    const ThingSetAccess _access;
-    const SubsetType _subset;
-
 public:
-    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, T *value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, T *value) :
         ThingSetValue<T *>(value),
-        IdentifiableThingSetNode(id, parentId, name),
-        _access(access),
-        _subset(subset)
+        IdentifiableThingSetNode(id, parentId, name)
     {}
 
     constexpr const std::string getType() const override
@@ -138,17 +124,17 @@ public:
 
     uint32_t getSubsets() const override
     {
-        return (uint32_t)_subset;
+        return (uint32_t)Subset;
     }
 
     ThingSetAccess getAccess() const override
     {
-        return _access;
+        return Access;
     }
 
     bool checkAccess(ThingSetAccess access) const override
     {
-        return (_access & access) == access;
+        return (Access & access) == access;
     }
 
     auto &operator=(T &value)
@@ -165,27 +151,20 @@ public:
 };
 
 /// @brief Partial specialisation of ThingSetProperty for record arrays.
-template <typename Element, std::size_t Size, typename SubsetType> requires std::is_class_v<Element>
-class ThingSetProperty<std::array<Element, Size>, SubsetType, ThingSetParentNode, IdentifiableThingSetParentNode>
+template <typename Element, std::size_t Size, ThingSetAccess Access, typename SubsetType, SubsetType Subset>
+    requires std::is_class_v<Element>
+class ThingSetProperty<std::array<Element, Size>, Access, SubsetType, Subset, ThingSetParentNode, IdentifiableThingSetParentNode>
     : public ThingSetValue<std::array<Element, Size>>, public IdentifiableThingSetParentNode,
       public ThingSetCustomRequestHandler
 {
-private:
-    const ThingSetAccess _access;
-    const SubsetType _subset;
-
 public:
-    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name) :
         ThingSetValue<std::array<Element, Size>>(),
-        IdentifiableThingSetParentNode(id, parentId, name),
-        _access(access),
-        _subset(subset)
+        IdentifiableThingSetParentNode(id, parentId, name)
     {}
-    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, const std::array<Element, Size> &value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, const std::array<Element, Size> &value) :
         ThingSetValue<std::array<Element, Size>>(value),
-        IdentifiableThingSetParentNode(id, parentId, name),
-        _access(access),
-        _subset(subset)
+        IdentifiableThingSetParentNode(id, parentId, name)
     {}
 
     using ThingSetValue<std::array<Element, Size>>::operator=;
@@ -225,17 +204,17 @@ public:
 
     uint32_t getSubsets() const override
     {
-        return (uint32_t)_subset;
+        return (uint32_t)Subset;
     }
 
     ThingSetAccess getAccess() const override
     {
-        return _access;
+        return Access;
     }
 
     bool checkAccess(ThingSetAccess access) const override
     {
-        return (_access & access) == access;
+        return (Access & access) == access;
     }
 
     bool findByName(const std::string &name, ThingSetNode **node, size_t *index) override
@@ -292,37 +271,38 @@ public:
     }
 };
 
-// /// @brief A ThingSet property that can be read by anyone.
-// /// @tparam T The type of the value stored by this property.
-// /// @tparam Id The unique ID of the property.
-// /// @tparam ParentId The ID of the parent container of this property.
-// /// @tparam Name The human-readable name of the property.
-// template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
-// using ThingSetReadOnlyProperty = ThingSetProperty<T, Subset>(Id, ParentId, Name, ThingSetAccess::anyRead, S);
+/// @brief A ThingSet property that can be read by anyone.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <typename T, Subset S = (Subset)0>
+using ThingSetReadOnlyProperty = ThingSetProperty<T, ThingSetAccess::anyRead, Subset, S>;
 
-// /// @brief A ThingSet property that can be read and written by anyone.
-// /// @tparam T The type of the value stored by this property.
-// /// @tparam Id The unique ID of the property.
-// /// @tparam ParentId The ID of the parent container of this property.
-// /// @tparam Name The human-readable name of the property.
-// template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
-// using ThingSetReadWriteProperty = ThingSetProperty<T, Subset>(Id, ParentId, Name, ThingSetAccess::anyReadWrite, S);
+/// @brief A ThingSet property that can be read and written by anyone.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <typename T, Subset S = (Subset)0>
+using ThingSetReadWriteProperty = ThingSetProperty<T, ThingSetAccess::anyReadWrite, Subset, S>;
 
-// /// @brief A ThingSet property that can be read by anyone but only written by advanced users.
-// /// @tparam T The type of the value stored by this property.
-// /// @tparam Id The unique ID of the property.
-// /// @tparam ParentId The ID of the parent container of this property.
-// /// @tparam Name The human-readable name of the property.
-// template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
-// using ThingSetReadAdvancedWriteProperty = ThingSetProperty<T, Subset>(Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, S);
+/// @brief A ThingSet property that can be read by anyone but only written by advanced users.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <typename T, Subset S = (Subset)0>
+using ThingSetReadAdvancedWriteProperty =
+    ThingSetProperty<T, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, Subset, S>;
 
-// /// @brief A ThingSet property that can be read by anyone but only written by the manufacturer.
-// /// @tparam T The type of the value stored by this property.
-// /// @tparam Id The unique ID of the property.
-// /// @tparam ParentId The ID of the parent container of this property.
-// /// @tparam Name The human-readable name of the property.
-// template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
-// using ThingSetReadManufacturerWriteProperty =
-//     ThingSetProperty<T, Subset>(Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::manufacturerWrite, S);
+/// @brief A ThingSet property that can be read by anyone but only written by the manufacturer.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <typename T, Subset S = (Subset)0>
+using ThingSetReadManufacturerWriteProperty =
+    ThingSetProperty<T, ThingSetAccess::anyRead | ThingSetAccess::manufacturerWrite, Subset, S>;
 
 } // namespace ThingSet

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -12,9 +12,6 @@
 
 namespace ThingSet {
 
-template <typename T, typename Base>
-concept IdentifiableBase = std::is_base_of_v<_IdentifiableThingSetNode<Base>, T>;
-
 enum struct Subset : uint8_t
 {
     persisted = 1 << 0,

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -95,27 +95,6 @@ public:
     }
 };
 
-// /// @brief Encapsulates a ThingSet property, which is a value that can be read and/or written via the ThingSet API.
-// /// @tparam T The type of the value stored by this property.
-// /// @tparam Id The unique ID of the property.
-// /// @tparam ParentId The ID of the parent container of this property.
-// /// @tparam Name The human-readable name of the property.
-// /// @tparam Access The access permissions for this property.
-// template <typename T, typename SubsetType = Subset> requires std::is_enum_v<SubsetType>
-// class ThingSetProperty : public _ThingSetProperty<ThingSetNode,
-//                                                   IdentifiableThingSetNode, T, SubsetType>
-// {
-// public:
-//     ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0)
-//         : _ThingSetProperty<ThingSetNode, IdentifiableThingSetNode, T, SubsetType>(id, parentId, name, access, subset)
-//     {}
-//     ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, const T &value, SubsetType subset = (SubsetType)0)
-//         : _ThingSetProperty<ThingSetNode, IdentifiableThingSetNode, T, SubsetType>(id, parentId, name, access, value, subset)
-//     {}
-
-//     using ThingSetValue<T>::operator =;
-// };
-
 /// @brief Partial specialisation of ThingSetProperty for pointers to values.
 template <typename T, typename SubsetType> requires std::is_enum_v<SubsetType>
 class ThingSetProperty<T *, SubsetType, ThingSetNode, IdentifiableThingSetNode>

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -72,7 +72,7 @@ public:
 /// @tparam NodeBase Ultimate base class.
 /// @tparam Base Intermediate base class.
 template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0>
-          requires std::is_enum_v<SubsetType>
+          requires std::is_integral_v<SubsetType> or std::is_enum_v<SubsetType>
 class ThingSetProperty : public ThingSetValue<T>, public ThingSetNode
 {
 private:
@@ -154,7 +154,8 @@ public:
 };
 
 /// @brief Partial specialisation of ThingSetProperty for pointers to values.
-template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset> requires std::is_enum_v<SubsetType>
+template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset>
+    requires std::is_integral_v<SubsetType> or std::is_enum_v<SubsetType>
 class ThingSetProperty<T *, Access, SubsetType, Subset>
     : public ThingSetValue<T *>, public ThingSetNode
 {

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -88,11 +88,6 @@ public:
         return ThingSetType<T>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -115,11 +110,6 @@ public:
     ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == access;
     }
 };
 
@@ -169,11 +159,6 @@ public:
         return ThingSetType<std::remove_pointer_t<T>>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -196,11 +181,6 @@ public:
     ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == access;
     }
 
     auto &operator=(T &value)
@@ -282,11 +262,6 @@ public:
         return ThingSetType<std::array<Element, Size>>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -312,11 +287,6 @@ public:
     ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == access;
     }
 
     bool findByName(const std::string &name, ThingSetNode **node, size_t *index) override

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -71,9 +71,9 @@ public:
 /// @tparam T Type of value.
 /// @tparam NodeBase Ultimate base class.
 /// @tparam Base Intermediate base class.
-template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0, NodeBase Base = ThingSetNode>
+template <typename T, ThingSetAccess Access, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0>
           requires std::is_enum_v<SubsetType>
-class ThingSetProperty : public ThingSetValue<T>, public Base
+class ThingSetProperty : public ThingSetValue<T>, public ThingSetNode
 {
 private:
     const uint16_t _id;
@@ -83,7 +83,7 @@ private:
 public:
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name) :
         ThingSetValue<T>(),
-        Base(),
+        ThingSetNode(),
         _id(id),
         _parentId(parentId),
         _name(name)
@@ -93,7 +93,7 @@ public:
 
     ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, const T &value) :
         ThingSetValue<T>(value),
-        Base(),
+        ThingSetNode(),
         _id(id),
         _parentId(parentId),
         _name(name)
@@ -138,7 +138,7 @@ public:
                 *target = static_cast<ThingSetDecodable *>(this);
                 return true;
             default:
-                return Base::tryCastTo(type, target);
+                return ThingSetNode::tryCastTo(type, target);
         }
     }
 
@@ -155,7 +155,7 @@ public:
 
 /// @brief Partial specialisation of ThingSetProperty for pointers to values.
 template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset> requires std::is_enum_v<SubsetType>
-class ThingSetProperty<T *, Access, SubsetType, Subset, ThingSetNode>
+class ThingSetProperty<T *, Access, SubsetType, Subset>
     : public ThingSetValue<T *>, public ThingSetNode
 {
 private:
@@ -239,7 +239,7 @@ public:
 /// @brief Partial specialisation of ThingSetProperty for record arrays.
 template <typename Element, std::size_t Size, ThingSetAccess Access, typename SubsetType, SubsetType Subset>
     requires std::is_class_v<Element>
-class ThingSetProperty<std::array<Element, Size>, Access, SubsetType, Subset, ThingSetParentNode>
+class ThingSetProperty<std::array<Element, Size>, Access, SubsetType, Subset>
     : public ThingSetValue<std::array<Element, Size>>, public ThingSetParentNode,
       public ThingSetCustomRequestHandler
 {

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -15,7 +15,7 @@ namespace ThingSet {
 template <typename T, typename Base>
 concept IdentifiableBase = std::is_base_of_v<_IdentifiableThingSetNode<Base>, T>;
 
-enum struct Subset
+enum struct Subset : uint8_t
 {
     persisted = 1 << 0,
     live = 1 << 1,
@@ -40,13 +40,13 @@ private:
     const SubsetType _subset;
 
 public:
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
         ThingSetValue<T>(),
         Base(id, parentId, name),
         _access(access),
         _subset(subset)
     {}
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, const T &value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, const T &value, SubsetType subset = (SubsetType)0) :
         ThingSetValue<T>(value),
         Base(id, parentId, name),
         _access(access),
@@ -105,7 +105,7 @@ private:
     const SubsetType _subset;
 
 public:
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, T *value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, T *value, SubsetType subset = (SubsetType)0) :
         ThingSetValue<T *>(value),
         IdentifiableThingSetNode(id, parentId, name),
         _access(access),
@@ -175,13 +175,13 @@ private:
     const SubsetType _subset;
 
 public:
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0) :
         ThingSetValue<std::array<Element, Size>>(),
         IdentifiableThingSetParentNode(id, parentId, name),
         _access(access),
         _subset(subset)
     {}
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, const std::array<Element, Size> &value, SubsetType subset = (SubsetType)0) :
+    ThingSetProperty(const uint16_t id, const uint16_t parentId, const std::string_view name, ThingSetAccess access, const std::array<Element, Size> &value, SubsetType subset = (SubsetType)0) :
         ThingSetValue<std::array<Element, Size>>(value),
         IdentifiableThingSetParentNode(id, parentId, name),
         _access(access),

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -140,11 +140,11 @@ class ThingSetProperty<std::array<Element, Size>, SubsetType>
       public ThingSetCustomRequestHandler
 {
 public:
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset)
+    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset = (SubsetType)0)
         : _ThingSetProperty<ThingSetParentNode, IdentifiableThingSetParentNode, std::array<Element, Size>, SubsetType>(id, parentId, name, access, subset)
     {}
-    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, SubsetType subset, const std::array<Element, Size> &value)
-        : _ThingSetProperty<ThingSetParentNode, IdentifiableThingSetParentNode, std::array<Element, Size>, SubsetType>(id, parentId, name, access, subset, value)
+    ThingSetProperty(const unsigned id, const unsigned parentId, const std::string_view name, ThingSetAccess access, const std::array<Element, Size> &value, SubsetType subset = (SubsetType)0)
+        : _ThingSetProperty<ThingSetParentNode, IdentifiableThingSetParentNode, std::array<Element, Size>, SubsetType>(id, parentId, name, access, value, subset)
     {}
 
     using ThingSetValue<std::array<Element, Size>>::operator =;

--- a/include/thingset++/ThingSetProperty.hpp
+++ b/include/thingset++/ThingSetProperty.hpp
@@ -210,7 +210,7 @@ public:
                 *target = static_cast<ThingSetDecodable *>(this);
                 return true;
             default:
-                return IdentifiableThingSetNode::tryCastTo(type, target);
+                return ThingSetNode::tryCastTo(type, target);
         }
     }
 

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -261,37 +261,7 @@ public:
 
     int handleRequest(ThingSetRequestContext &context) override
     {
-        if (context.isGet()) {
-            context.setStatus(ThingSetStatusCode::content);
-            context.encoder().encodePreamble();
-            if (context.index == SIZE_MAX) {
-                context.encoder().encode(
-#if defined(__APPLE__) || defined(__OpenBSD__)
-                    // working round ambiguity on macOS and OpenBSD
-                    // https://stackoverflow.com/questions/42004974/function-overloading-integer-types-and-stdsize-t-on-64-bit-systems
-                    static_cast<uint32_t>(
-#endif
-                        this->_value.size()
-#if defined(__APPLE__) || defined(__OpenBSD__)
-                    )
-#endif
-                );
-            }
-            else {
-                context.encoder().encode(this->_value[context.index]);
-            }
-            return context.getHeaderLength() + context.encoder().getEncodedLength();
-        }
-        else if (context.isUpdate()) {
-            context.setStatus(ThingSetStatusCode::changed);
-            context.encoder().encodePreamble();
-            if (context.index == SIZE_MAX) {
-                context.setStatus(ThingSetStatusCode::badRequest);
-            }
-            context.decoder().decode(&this->_value[context.index]);
-            return context.getHeaderLength();
-        }
-        return 0;
+        return ThingSetRecordPropertyHelpers::handleRequest(context, this->_value);
     }
 };
 

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -43,12 +43,12 @@ public:
         return Name.string_view();
     }
 
-    constexpr unsigned getId() const override
+    constexpr uint16_t getId() const override
     {
         return Id;
     }
 
-    constexpr unsigned getParentId() const override
+    constexpr uint16_t getParentId() const override
     {
         return ParentId;
     }
@@ -107,12 +107,12 @@ public:
         return Name.string_view();
     }
 
-    constexpr unsigned getId() const override
+    constexpr uint16_t getId() const override
     {
         return Id;
     }
 
-    constexpr unsigned getParentId() const override
+    constexpr uint16_t getParentId() const override
     {
         return ParentId;
     }
@@ -193,12 +193,12 @@ public:
         return Name.string_view();
     }
 
-    constexpr unsigned getId() const override
+    constexpr uint16_t getId() const override
     {
         return Id;
     }
 
-    constexpr unsigned getParentId() const override
+    constexpr uint16_t getParentId() const override
     {
         return ParentId;
     }

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -268,36 +268,36 @@ public:
     constexpr static const std::string_view &name = Name.string_view();
 };
 
-/// @brief A ThingSet property that can be read by anyone.
-/// @tparam T The type of the value stored by this property.
-/// @tparam Id The unique ID of the property.
-/// @tparam ParentId The ID of the parent container of this property.
-/// @tparam Name The human-readable name of the property.
+/// @brief A ThingSet record member that can be read by anyone.
+/// @tparam T The type of the value stored by this record member.
+/// @tparam Id The unique ID of the record member.
+/// @tparam ParentId The ID of the parent container of this record member.
+/// @tparam Name The human-readable name of the record member.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadOnlyRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead, T, Subset, S>;
 
-/// @brief A ThingSet property that can be read and written by anyone.
-/// @tparam T The type of the value stored by this property.
-/// @tparam Id The unique ID of the property.
-/// @tparam ParentId The ID of the parent container of this property.
-/// @tparam Name The human-readable name of the property.
+/// @brief A ThingSet record member that can be read and written by anyone.
+/// @tparam T The type of the value stored by this record member.
+/// @tparam Id The unique ID of the record member.
+/// @tparam ParentId The ID of the parent container of this record member.
+/// @tparam Name The human-readable name of the record member.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadWriteRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyReadWrite, T, Subset, S>;
 
-/// @brief A ThingSet property that can be read by anyone but only written by advanced users.
-/// @tparam T The type of the value stored by this property.
-/// @tparam Id The unique ID of the property.
-/// @tparam ParentId The ID of the parent container of this property.
-/// @tparam Name The human-readable name of the property.
+/// @brief A ThingSet record member that can be read by anyone but only written by advanced users.
+/// @tparam T The type of the value stored by this record member.
+/// @tparam Id The unique ID of the record member.
+/// @tparam ParentId The ID of the parent container of this record member.
+/// @tparam Name The human-readable name of the record member.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadAdvancedWriteRecordMember =
     ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;
 
-/// @brief A ThingSet property that can be read by anyone but only written by the manufacturer.
-/// @tparam T The type of the value stored by this property.
-/// @tparam Id The unique ID of the property.
-/// @tparam ParentId The ID of the parent container of this property.
-/// @tparam Name The human-readable name of the property.
+/// @brief A ThingSet record member that can be read by anyone but only written by the manufacturer.
+/// @tparam T The type of the value stored by this record member.
+/// @tparam Id The unique ID of the record member.
+/// @tparam ParentId The ID of the parent container of this record member.
+/// @tparam Name The human-readable name of the record member.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadManufacturerWriteRecordMember =
     ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2024 Brill Power.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "thingset++/ThingSetProperty.hpp"
+
+namespace ThingSet {
+
+template <unsigned Id, unsigned ParentId, StringLiteral Name, NodeBase NodeBase,
+          IdentifiableBase<NodeBase> Base, ThingSetAccess Access, typename T, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0>
+          requires std::is_enum_v<SubsetType>
+class _ThingSetRecordMember : public ThingSetValue<T>, public Base
+{
+protected:
+    _ThingSetRecordMember() : ThingSetValue<T>(), Base(Id, ParentId, Name.string_view())
+    {}
+    _ThingSetRecordMember(const T &value) : ThingSetValue<T>(value), Base(Id, ParentId, Name.string_view())
+    {}
+
+public:
+    constexpr const std::string getType() const override
+    {
+        return ThingSetType<std::remove_pointer_t<T>>::name.str();
+    }
+
+    constexpr ThingSetNodeType getNodeType() const override
+    {
+        return ThingSetNodeType::value;
+    }
+
+    bool tryCastTo(ThingSetNodeType type, void **target) override
+    {
+        switch (type) {
+            case ThingSetNodeType::encodable:
+                *target = static_cast<ThingSetEncodable *>(this);
+                return true;
+            case ThingSetNodeType::decodable:
+                *target = static_cast<ThingSetDecodable *>(this);
+                return true;
+            default:
+                return Base::tryCastTo(type, target);
+        }
+    }
+
+    constexpr uint32_t getSubsets() const override
+    {
+        return (uint32_t)Subset;
+    }
+
+    constexpr ThingSetAccess getAccess() const override
+    {
+        return Access;
+    }
+
+    bool checkAccess(ThingSetAccess access) const override
+    {
+        return (Access & access) == Access;
+    }
+
+    constexpr static const unsigned id = Id;
+    constexpr static const std::string_view &name = Name.string_view();
+};
+
+/// @brief Encapsulates a ThingSet property, which is a value that can be read and/or written via the ThingSet API.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+/// @tparam Access The access permissions for this property.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset, SubsetType Subset = (SubsetType)0>
+    requires std::is_enum_v<SubsetType>
+class ThingSetRecordMember : public _ThingSetRecordMember<Id, ParentId, Name, ThingSetNode,
+                                                  IdentifiableThingSetNode, Access, T, SubsetType, Subset>
+{
+public:
+    ThingSetRecordMember()
+        : _ThingSetRecordMember<Id, ParentId, Name, ThingSetNode, IdentifiableThingSetNode, Access, T, SubsetType, Subset>()
+    {}
+    ThingSetRecordMember(const T &value)
+        : _ThingSetRecordMember<Id, ParentId, Name, ThingSetNode, IdentifiableThingSetNode, Access, T, SubsetType, Subset>(
+              value)
+    {}
+
+    auto &operator=(const T &value)
+    {
+        this->_value = value;
+        return *this;
+    }
+
+    auto &operator=(T &&value)
+    {
+        this->_value = std::move(value);
+        return *this;
+    }
+};
+
+/// @brief Partial specialisation of ThingSetRecordMember for pointers to values.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType, SubsetType Subset>
+class ThingSetRecordMember<Id, ParentId, Name, Access, T *, SubsetType, Subset>
+    : public _ThingSetRecordMember<Id, ParentId, Name, ThingSetNode, IdentifiableThingSetNode, Access, T *, SubsetType, Subset>
+{
+public:
+    ThingSetRecordMember(T *value)
+        : _ThingSetRecordMember<Id, ParentId, Name, ThingSetNode, IdentifiableThingSetNode, Access, T *, SubsetType, Subset>(value)
+    {}
+
+    auto &operator=(T &value)
+    {
+        *this->_value = value;
+    }
+
+    auto &operator=(T &&value)
+    {
+        *this->_value = std::move(value);
+        return *this;
+    }
+};
+
+/// @brief Partial specialisation of ThingSetRecordMember for record arrays.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename Element, std::size_t Size, typename SubsetType, SubsetType Subset>
+    requires std::is_class_v<Element>
+class ThingSetRecordMember<Id, ParentId, Name, Access, std::array<Element, Size>, SubsetType, Subset>
+    : public _ThingSetRecordMember<Id, ParentId, Name, ThingSetParentNode,
+                               IdentifiableThingSetParentNode, Access, std::array<Element, Size>, SubsetType, Subset>,
+      public ThingSetCustomRequestHandler
+{
+public:
+    ThingSetRecordMember()
+        : _ThingSetRecordMember<Id, ParentId, Name, ThingSetParentNode, IdentifiableThingSetParentNode,
+                            Access, std::array<Element, Size>, SubsetType, Subset>()
+    {}
+    ThingSetRecordMember(const std::array<Element, Size> &value)
+        : _ThingSetRecordMember<Id, ParentId, Name, ThingSetParentNode, IdentifiableThingSetParentNode,
+                            Access, std::array<Element, Size>, SubsetType, Subset>(value)
+    {}
+
+    auto &operator=(const std::array<Element, Size> &value)
+    {
+        this->_value = value;
+        return *this;
+    }
+
+    auto &operator=(std::array<Element, Size> &&value)
+    {
+        this->_value = std::move(value);
+        return *this;
+    }
+
+    ThingSetParentNode::ChildIterator begin() override
+    {
+        // don't expose child nodes
+        return this->end();
+    }
+
+    bool tryCastTo(ThingSetNodeType type, void **target) override
+    {
+        if (!_ThingSetRecordMember<Id, ParentId, Name, ThingSetParentNode,
+                               IdentifiableThingSetParentNode, Access,
+                               std::array<Element, Size>, SubsetType, Subset>::tryCastTo(type, target))
+        {
+            if (type == ThingSetNodeType::requestHandler) {
+                *target = static_cast<ThingSetCustomRequestHandler *>(this);
+                return true;
+            }
+
+            return false;
+        }
+        return true;
+    }
+
+    bool findByName(const std::string &name, ThingSetNode **node, size_t *index) override
+    {
+        bool foundChild = ThingSetParentNode::findByName(name, node, index);
+        // atoi is useless - it returns 0 on failure - so we check that the string actually
+        // contains a number before trying to parse it
+        if (name.c_str()[0] >= '0' && name.c_str()[0] <= '9') {
+            *index = std::atoi(name.c_str());
+            return true;
+        }
+
+        return foundChild;
+    }
+
+    bool invokeCallback(ThingSetNode *, ThingSetCallbackReason) const override
+    {
+        return true;
+    }
+
+    int handleRequest(ThingSetRequestContext &context) override
+    {
+        if (context.isGet()) {
+            context.setStatus(ThingSetStatusCode::content);
+            context.encoder().encodePreamble();
+            if (context.index == SIZE_MAX) {
+                context.encoder().encode(
+#if defined(__APPLE__) || defined(__OpenBSD__)
+                    // working round ambiguity on macOS and OpenBSD
+                    // https://stackoverflow.com/questions/42004974/function-overloading-integer-types-and-stdsize-t-on-64-bit-systems
+                    static_cast<uint32_t>(
+#endif
+                        this->_value.size()
+#if defined(__APPLE__) || defined(__OpenBSD__)
+                    )
+#endif
+                );
+            }
+            else {
+                context.encoder().encode(this->_value[context.index]);
+            }
+            return context.getHeaderLength() + context.encoder().getEncodedLength();
+        }
+        else if (context.isUpdate()) {
+            context.setStatus(ThingSetStatusCode::changed);
+            context.encoder().encodePreamble();
+            if (context.index == SIZE_MAX) {
+                context.setStatus(ThingSetStatusCode::badRequest);
+            }
+            context.decoder().decode(&this->_value[context.index]);
+            return context.getHeaderLength();
+        }
+        return 0;
+    }
+};
+
+/// @brief A ThingSet property that can be read by anyone.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+using ThingSetReadOnlyRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead, T, Subset, S>;
+
+/// @brief A ThingSet property that can be read and written by anyone.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+using ThingSetReadWriteRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyReadWrite, T, Subset, S>;
+
+/// @brief A ThingSet property that can be read by anyone but only written by advanced users.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+using ThingSetReadAdvancedWriteRecordMember =
+    ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;
+
+/// @brief A ThingSet property that can be read by anyone but only written by the manufacturer.
+/// @tparam T The type of the value stored by this property.
+/// @tparam Id The unique ID of the property.
+/// @tparam ParentId The ID of the parent container of this property.
+/// @tparam Name The human-readable name of the property.
+template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+using ThingSetReadManufacturerWriteRecordMember =
+    ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;
+
+
+} // namespace ThingSet

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -16,17 +16,17 @@ namespace ThingSet {
 /// @tparam Name The human-readable name of the property.
 /// @tparam Access The access permissions for this property.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset,
-          SubsetType Subset = (SubsetType)0, NodeBase Base = ThingSetNode>
+          SubsetType Subset = (SubsetType)0>
           requires std::is_enum_v<SubsetType>
-class ThingSetRecordMember : public ThingSetValue<T>, public Base
+class ThingSetRecordMember : public ThingSetValue<T>, public ThingSetNode
 {
 public:
-    ThingSetRecordMember() : ThingSetValue<T>(), Base()
+    ThingSetRecordMember() : ThingSetValue<T>(), ThingSetNode()
     {
         ThingSetRegistry::registerNode(this);
     }
 
-    ThingSetRecordMember(const T &value) : ThingSetValue<T>(value), Base()
+    ThingSetRecordMember(const T &value) : ThingSetValue<T>(value), ThingSetNode()
     {
         ThingSetRegistry::registerNode(this);
     }
@@ -68,7 +68,7 @@ public:
                 *target = static_cast<ThingSetDecodable *>(this);
                 return true;
             default:
-                return Base::tryCastTo(type, target);
+                return ThingSetNode::tryCastTo(type, target);
         }
     }
 
@@ -88,7 +88,7 @@ public:
 
 /// @brief Partial specialisation of ThingSetRecordMember for pointers to values.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType, SubsetType Subset>
-class ThingSetRecordMember<Id, ParentId, Name, Access, T *, SubsetType, Subset, ThingSetNode>
+class ThingSetRecordMember<Id, ParentId, Name, Access, T *, SubsetType, Subset>
     : public ThingSetValue<T *>, public ThingSetNode
 {
 public:
@@ -165,7 +165,7 @@ public:
 /// @brief Partial specialisation of ThingSetRecordMember for record arrays.
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename Element, std::size_t Size, typename SubsetType, SubsetType Subset>
     requires std::is_class_v<Element>
-class ThingSetRecordMember<Id, ParentId, Name, Access, std::array<Element, Size>, SubsetType, Subset, ThingSetParentNode>
+class ThingSetRecordMember<Id, ParentId, Name, Access, std::array<Element, Size>, SubsetType, Subset>
     : public ThingSetValue<std::array<Element, Size>>, public ThingSetParentNode,
       public ThingSetCustomRequestHandler
 {
@@ -263,6 +263,9 @@ public:
     {
         return ThingSetRecordPropertyHelpers::handleRequest(context, this->_value);
     }
+
+    constexpr static const unsigned id = Id;
+    constexpr static const std::string_view &name = Name.string_view();
 };
 
 /// @brief A ThingSet property that can be read by anyone.

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -15,7 +15,7 @@ namespace ThingSet {
 /// @tparam ParentId The ID of the parent container of this property.
 /// @tparam Name The human-readable name of the property.
 /// @tparam Access The access permissions for this property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset,
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset,
           SubsetType Subset = (SubsetType)0, NodeBase NodeBase = ThingSetNode, IdentifiableBase<NodeBase> Base = IdentifiableThingSetNode>
           requires std::is_enum_v<SubsetType>
 class ThingSetRecordMember : public ThingSetValue<T>, public Base
@@ -72,7 +72,7 @@ public:
 };
 
 /// @brief Partial specialisation of ThingSetRecordMember for pointers to values.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType, SubsetType Subset>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType, SubsetType Subset>
 class ThingSetRecordMember<Id, ParentId, Name, Access, T *, SubsetType, Subset, ThingSetNode, IdentifiableThingSetNode>
     : public ThingSetValue<T *>, public IdentifiableThingSetNode
 {
@@ -131,12 +131,12 @@ public:
         return *this;
     }
 
-    constexpr static const unsigned id = Id;
+    constexpr static const uint16_t id = Id;
     constexpr static const std::string_view &name = Name.string_view();
 };
 
 /// @brief Partial specialisation of ThingSetRecordMember for record arrays.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename Element, std::size_t Size, typename SubsetType, SubsetType Subset>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, ThingSetAccess Access, typename Element, std::size_t Size, typename SubsetType, SubsetType Subset>
     requires std::is_class_v<Element>
 class ThingSetRecordMember<Id, ParentId, Name, Access, std::array<Element, Size>, SubsetType, Subset, ThingSetParentNode, IdentifiableThingSetParentNode>
     : public ThingSetValue<std::array<Element, Size>>, public IdentifiableThingSetParentNode,
@@ -258,7 +258,7 @@ public:
 /// @tparam Id The unique ID of the property.
 /// @tparam ParentId The ID of the parent container of this property.
 /// @tparam Name The human-readable name of the property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadOnlyRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead, T, Subset, S>;
 
 /// @brief A ThingSet property that can be read and written by anyone.
@@ -266,7 +266,7 @@ using ThingSetReadOnlyRecordMember = ThingSetRecordMember<Id, ParentId, Name, Th
 /// @tparam Id The unique ID of the property.
 /// @tparam ParentId The ID of the parent container of this property.
 /// @tparam Name The human-readable name of the property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadWriteRecordMember = ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyReadWrite, T, Subset, S>;
 
 /// @brief A ThingSet property that can be read by anyone but only written by advanced users.
@@ -274,7 +274,7 @@ using ThingSetReadWriteRecordMember = ThingSetRecordMember<Id, ParentId, Name, T
 /// @tparam Id The unique ID of the property.
 /// @tparam ParentId The ID of the parent container of this property.
 /// @tparam Name The human-readable name of the property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadAdvancedWriteRecordMember =
     ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;
 
@@ -283,7 +283,7 @@ using ThingSetReadAdvancedWriteRecordMember =
 /// @tparam Id The unique ID of the property.
 /// @tparam ParentId The ID of the parent container of this property.
 /// @tparam Name The human-readable name of the property.
-template <unsigned Id, unsigned ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
+template <uint16_t Id, uint16_t ParentId, StringLiteral Name, typename T, Subset S = (Subset)0>
 using ThingSetReadManufacturerWriteRecordMember =
     ThingSetRecordMember<Id, ParentId, Name, ThingSetAccess::anyRead | ThingSetAccess::expertWrite, T, Subset, S>;
 

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -58,11 +58,6 @@ public:
         return ThingSetType<T>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -85,11 +80,6 @@ public:
     constexpr ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == Access;
     }
 
     constexpr static const unsigned id = Id;
@@ -132,11 +122,6 @@ public:
         return ThingSetType<std::remove_pointer_t<T>>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -159,11 +144,6 @@ public:
     constexpr ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == Access;
     }
 
     auto &operator=(T &value)
@@ -234,11 +214,6 @@ public:
         return ThingSetType<std::array<Element, Size>>::name.str();
     }
 
-    constexpr ThingSetNodeType getNodeType() const override
-    {
-        return ThingSetNodeType::value;
-    }
-
     bool tryCastTo(ThingSetNodeType type, void **target) override
     {
         switch (type) {
@@ -264,11 +239,6 @@ public:
     constexpr ThingSetAccess getAccess() const override
     {
         return Access;
-    }
-
-    bool checkAccess(ThingSetAccess access) const override
-    {
-        return (Access & access) == Access;
     }
 
     bool findByName(const std::string &name, ThingSetNode **node, size_t *index) override

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -132,7 +132,7 @@ public:
                 *target = static_cast<ThingSetDecodable *>(this);
                 return true;
             default:
-                return IdentifiableThingSetNode::tryCastTo(type, target);
+                return ThingSetNode::tryCastTo(type, target);
         }
     }
 

--- a/include/thingset++/ThingSetRecordMember.hpp
+++ b/include/thingset++/ThingSetRecordMember.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Brill Power.
+ * Copyright (c) 2025 Brill Power.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/thingset++/ThingSetRegistry.hpp
+++ b/include/thingset++/ThingSetRegistry.hpp
@@ -24,7 +24,7 @@ typedef std::array<NodeList, NODE_MAP_LOOKUP_BUCKETS> NodeMap;
 class ThingSetRegistry
 {
 private:
-    template <unsigned Id, unsigned ParentId, StringLiteral Name>
+    template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
     class OverlayNode : public ThingSetParentNode
     {
     public:
@@ -33,12 +33,12 @@ private:
             return Name.string_view();
         }
 
-        constexpr virtual unsigned getId() const override
+        constexpr virtual uint16_t getId() const override
         {
             return Id;
         }
 
-        constexpr virtual unsigned getParentId() const override
+        constexpr virtual uint16_t getParentId() const override
         {
             return ParentId;
         }

--- a/include/thingset++/ThingSetRegistry.hpp
+++ b/include/thingset++/ThingSetRegistry.hpp
@@ -48,11 +48,6 @@ private:
             return "group";
         }
 
-        constexpr ThingSetNodeType getNodeType() const override
-        {
-            return ThingSetNodeType::group;
-        }
-
         bool tryCastTo(ThingSetNodeType type, void **target) override
         {
             switch (type) {
@@ -67,11 +62,6 @@ private:
         ThingSetAccess getAccess() const override
         {
             return ThingSetAccess::userRead;
-        }
-
-        bool checkAccess(ThingSetAccess) const override
-        {
-            return true;
         }
 
         bool invokeCallback(ThingSetNode *, ThingSetCallbackReason) const override

--- a/include/thingset++/ThingSetServer.hpp
+++ b/include/thingset++/ThingSetServer.hpp
@@ -49,16 +49,16 @@ protected:
     int handleBinaryRequest(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize);
     int handleTextRequest(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize);
 
-    template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset, SubsetType Subset,
+    template <typename T, typename SubsetType = Subset,
               EncodableDecodableNode... Property>
-    bool encode(ThingSetEncoder &encoder, ThingSetProperty<Id, ParentId, Name, Access, T, SubsetType, Subset> &property,
+    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, SubsetType> &property,
                 Property &...properties)
     {
         return encode(encoder, property) && encode(encoder, properties...);
     }
 
-    template <unsigned Id, unsigned ParentId, StringLiteral Name, ThingSetAccess Access, typename T, typename SubsetType = Subset, SubsetType Subset>
-    bool encode(ThingSetEncoder &encoder, ThingSetProperty<Id, ParentId, Name, Access, T, SubsetType, Subset> &property)
+    template <typename T, typename SubsetType = Subset>
+    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, SubsetType> &property)
     {
         return encoder.encode(property.getId()) && encoder.encode(property.getValue());
     }

--- a/include/thingset++/ThingSetServer.hpp
+++ b/include/thingset++/ThingSetServer.hpp
@@ -49,16 +49,16 @@ protected:
     int handleBinaryRequest(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize);
     int handleTextRequest(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize);
 
-    template <typename T, typename SubsetType = Subset,
+    template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset,
               EncodableDecodableNode... Property>
-    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, SubsetType> &property,
+    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, Access, SubsetType, Subset> &property,
                 Property &...properties)
     {
         return encode(encoder, property) && encode(encoder, properties...);
     }
 
-    template <typename T, typename SubsetType = Subset>
-    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, SubsetType> &property)
+    template <typename T, ThingSetAccess Access, typename SubsetType, SubsetType Subset>
+    bool encode(ThingSetEncoder &encoder, ThingSetProperty<T, Access, SubsetType, Subset> &property)
     {
         return encoder.encode(property.getId()) && encoder.encode(property.getValue());
     }

--- a/include/thingset++/ThingSetTextDecoder.hpp
+++ b/include/thingset++/ThingSetTextDecoder.hpp
@@ -27,7 +27,7 @@ protected:
     const char *_inputBuffer;
     size_t _bufferSize;
     size_t _bufferElemPtr;
-    size_t _tokenPtr;
+    size_t _tokenIndex;
     jsmn_parser _parser;
 
     ThingSetTextDecoder(const char *buffer, const size_t size);

--- a/include/thingset++/ThingSetValue.hpp
+++ b/include/thingset++/ThingSetValue.hpp
@@ -88,7 +88,7 @@ public:
     auto &operator=(const U &value)
     {
         _value = value;
-        return this;
+        return *this;
     }
 };
 

--- a/include/thingset++/ThingSetValue.hpp
+++ b/include/thingset++/ThingSetValue.hpp
@@ -132,6 +132,18 @@ public:
         return _value[index];
     }
 
+    auto &operator=(const std::array<Element, Size> &value)
+    {
+        _value = value;
+        return *this;
+    }
+
+    auto &operator=(std::array<Element, Size> &&value)
+    {
+        _value = std::move(value);
+        return *this;
+    }
+
     std::size_t size() const
     {
         return _value.size();

--- a/src/ThingSetServer.cpp
+++ b/src/ThingSetServer.cpp
@@ -204,7 +204,7 @@ int _ThingSetServer::handleUpdate(ThingSetRequestContext &context)
             context.setStatus(ThingSetStatusCode::notFound);
             return false;
         }
-        if ((child->getAccess() & _access) != _access) {
+        if ((child->getAccess() & _access) == ThingSetAccess::none) {
             context.setStatus(ThingSetStatusCode::forbidden);
             return false;
         }
@@ -235,7 +235,7 @@ int _ThingSetServer::handleUpdate(ThingSetRequestContext &context)
 
 int _ThingSetServer::handleExec(ThingSetRequestContext &context)
 {
-    if ((context.node->getAccess() & _access) != _access) {
+    if ((context.node->getAccess() & _access) == ThingSetAccess::none) {
         context.setStatus(ThingSetStatusCode::forbidden);
         return context.getHeaderLength();
     }

--- a/src/ThingSetServer.cpp
+++ b/src/ThingSetServer.cpp
@@ -13,7 +13,7 @@
 
 namespace ThingSet {
 
-static inline ThingSetProperty<std::string> nodeId { 0x1d, 0, "NodeID", ThingSetAccess::userRead, Eui::getString() };
+static inline ThingSetReadOnlyProperty<std::string> nodeId { 0x1d, 0, "NodeID", Eui::getString() };
 static const uint16_t MetadataNameId = 0x1a;
 static const uint16_t MetadataTypeId = 0x1b;
 static const uint16_t MetadataAccessId = 0x1c;

--- a/src/ThingSetServer.cpp
+++ b/src/ThingSetServer.cpp
@@ -204,7 +204,7 @@ int _ThingSetServer::handleUpdate(ThingSetRequestContext &context)
             context.setStatus(ThingSetStatusCode::notFound);
             return false;
         }
-        if (!child->checkAccess(_access)) {
+        if ((child->getAccess() & _access) != _access) {
             context.setStatus(ThingSetStatusCode::forbidden);
             return false;
         }
@@ -235,7 +235,7 @@ int _ThingSetServer::handleUpdate(ThingSetRequestContext &context)
 
 int _ThingSetServer::handleExec(ThingSetRequestContext &context)
 {
-    if (!context.node->checkAccess(_access)) {
+    if ((context.node->getAccess() & _access) != _access) {
         context.setStatus(ThingSetStatusCode::forbidden);
         return context.getHeaderLength();
     }

--- a/src/ThingSetServer.cpp
+++ b/src/ThingSetServer.cpp
@@ -13,7 +13,7 @@
 
 namespace ThingSet {
 
-static inline ThingSetProperty<0x1d, 0, "NodeID", ThingSetAccess::userRead, std::string> nodeId(Eui::getString());
+static inline ThingSetProperty<std::string> nodeId { 0x1d, 0, "NodeID", ThingSetAccess::userRead, Eui::getString() };
 static const uint16_t MetadataNameId = 0x1a;
 static const uint16_t MetadataTypeId = 0x1b;
 static const uint16_t MetadataAccessId = 0x1c;

--- a/src/ThingSetTextDecoder.cpp
+++ b/src/ThingSetTextDecoder.cpp
@@ -8,7 +8,7 @@
 
 namespace ThingSet {
 
-ThingSetTextDecoder::ThingSetTextDecoder(const char *buffer, const size_t size) : _inputBuffer(buffer), _bufferSize(size), _bufferElemPtr(0), _tokenPtr(0)
+ThingSetTextDecoder::ThingSetTextDecoder(const char *buffer, const size_t size) : _inputBuffer(buffer), _bufferSize(size), _bufferElemPtr(0), _tokenIndex(0)
 {
     jsmn_init(&_parser);
 }
@@ -189,7 +189,7 @@ bool ThingSetTextDecoder::isInList() const
 
 ThingSetEncodedNodeType ThingSetTextDecoder::peekType()
 {
-    jsmntok *token = &getTokens()[_tokenPtr];
+    jsmntok *token = &getTokens()[_tokenIndex];
     switch (token->type)
     {
         case JSMN_PRIMITIVE:
@@ -213,7 +213,7 @@ bool ThingSetTextDecoder::ensureListSize(const size_t size, size_t &elementCount
 
 bool ThingSetTextDecoder::expectType(const jsmntype_t &type, jsmntok **t)
 {
-    jsmntok *token = &getTokens()[_tokenPtr];
+    jsmntok *token = &getTokens()[_tokenIndex];
     if (t) {
         *t = token;
     }
@@ -226,14 +226,14 @@ bool ThingSetTextDecoder::expectType(const jsmntype_t &type, jsmntok **t)
         offset = 1;
     }
     _bufferElemPtr = token->start + offset;
-    _tokenPtr++;
+    _tokenIndex++;
     return true;
 }
 
 bool ThingSetTextDecoder::skip()
 {
-    _tokenPtr++;
-    jsmntok *token = &getTokens()[_tokenPtr];
+    _tokenIndex++;
+    jsmntok *token = &getTokens()[_tokenIndex];
     _bufferElemPtr = token->start;
     return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,13 +27,11 @@ target_sources(testapp PRIVATE TestBinaryEncoder.cpp
     TestFunctions.cpp
     TestSubsets.cpp
     TestAsioIpClientServer.cpp
+    TestBinaryEncodingRecords.cpp
     TestBinaryDecodingRecords.cpp
     TestTextEncodingRecords.cpp
     TestRequestRewriter.cpp)
-# figure out how to get this to compile with Clang
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_sources(testapp PRIVATE TestBinaryEncodingRecords.cpp)
-endif()
+
 # regrettably exlcude this test until we figure out why Socket server is broken on macOS
 if(NOT APPLE)
     target_sources(testapp PRIVATE TestSocketIpClientServer.cpp)

--- a/tests/TestAsioIpClientServer.cpp
+++ b/tests/TestAsioIpClientServer.cpp
@@ -54,9 +54,15 @@ TEST(AsioIpClientServer, Name) \
     ASSERT_TRUE(clientRanSuccessfully); \
 }
 
-ASIO_TEST(GetFloat,
+ASIO_TEST(GetFloatById,
     float tv;
     ASSERT_TRUE(client.get(0x300, tv));
+    ASSERT_EQ(24.0f, tv);
+)
+
+ASIO_TEST(GetFloatByName,
+    float tv;
+    ASSERT_TRUE(client.get("totalVoltage", tv));
     ASSERT_EQ(24.0f, tv);
 )
 

--- a/tests/TestAsioIpClientServer.cpp
+++ b/tests/TestAsioIpClientServer.cpp
@@ -22,7 +22,7 @@ static std::array<uint8_t, 1024> txBuffer;
 #define ASIO_TEST(Name, Body) \
 TEST(AsioIpClientServer, Name) \
 { \
-    ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24; \
+    ThingSetProperty totalVoltage { 0x300, 0, "totalVoltage", ThingSetAccess::anyReadWrite, 24.0f }; \
     ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; }); \
 \
     io_context serverContext(1); \

--- a/tests/TestAsioIpClientServer.cpp
+++ b/tests/TestAsioIpClientServer.cpp
@@ -22,7 +22,7 @@ static std::array<uint8_t, 1024> txBuffer;
 #define ASIO_TEST(Name, Body) \
 TEST(AsioIpClientServer, Name) \
 { \
-    ThingSetProperty totalVoltage { 0x300, 0, "totalVoltage", ThingSetAccess::anyReadWrite, 24.0f }; \
+    ThingSetReadWriteProperty totalVoltage { 0x300, 0, "totalVoltage", 24.0f }; \
     ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; }); \
 \
     io_context serverContext(1); \

--- a/tests/TestBinaryDecodingRecords.cpp
+++ b/tests/TestBinaryDecodingRecords.cpp
@@ -4,28 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "thingset++/ThingSet.hpp"
-// #include "thingset++/ThingSetBinaryEncoder.hpp"
-// #include "thingset++/ThingSetBinaryDecoder.hpp"
+#include "thingset++/ThingSetRecordMember.hpp"
 #include "gtest/gtest.h"
 
 using namespace ThingSet;
 
 struct SimpleRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadOnlyRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadOnlyRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadOnlyRecordMember<0x603, 0x600, "error", uint64_t> error;
 };
 
 struct SimplerRecord
 {
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadOnlyRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadOnlyRecordMember<0x603, 0x600, "error", uint64_t> error;
 };
 
 TEST(BinaryRecords, DecodeToRecordWhichIsSubsetOfDataOnWire)
 {
-    ThingSetReadOnlyProperty<0x610, 0, "Simples", std::array<SimpleRecord, 1>> simples = {
+    ThingSetReadOnlyRecordMember<0x610, 0, "Simples", std::array<SimpleRecord, 1>> simples = {
         {
             (SimpleRecord){
                 .voltage = 24.0f,
@@ -35,7 +34,7 @@ TEST(BinaryRecords, DecodeToRecordWhichIsSubsetOfDataOnWire)
         }
     };
 
-    ThingSetReadOnlyProperty<0x611, 0, "Simplers", std::array<SimplerRecord, 1>> simplers;
+    ThingSetReadOnlyRecordMember<0x611, 0, "Simplers", std::array<SimplerRecord, 1>> simplers;
 
     std::array<uint8_t, 512> buffer;
     FixedDepthThingSetBinaryEncoder encoder(buffer);

--- a/tests/TestBinaryEncodingRecords.cpp
+++ b/tests/TestBinaryEncodingRecords.cpp
@@ -10,18 +10,18 @@ using namespace ThingSet;
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadOnlyRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadOnlyRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
     bool ignored; // this field will be ignored by the encoder and decoder
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadOnlyRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadOnlyRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadOnlyRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadOnlyRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadOnlyRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
 #define ASSERT_BUFFER_EQ(expected, actual, actual_len)                                                                 \
@@ -31,8 +31,8 @@ struct ModuleRecord
     }
 
 #define SETUP()                                                                                                        \
-    ThingSetReadOnlyProperty<0x610, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords = {                       \
-        { (ModuleRecord){                                                                                              \
+    ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> moduleRecords { 0x610, 0, "Modules",                         \
+         { (ModuleRecord){                                                                                             \
               .voltage = 24.0f,                                                                                        \
               .current = 10.0f,                                                                                        \
               .error = 0,                                                                                              \
@@ -64,8 +64,8 @@ struct ModuleRecord
               .current = 5.0f,                                                                                         \
               .error = 0,                                                                                              \
               .cellVoltages = { { 3.1f, 3.3f, 3.0f, 3.1f, 3.2f, 2.95f } },                                             \
-          } }                                                                                                          \
-    };
+          }                                                                                                            \
+    } };
 
 TEST(BinaryRecords, EncodeAndDecodeSimpleRecord)
 {
@@ -99,7 +99,7 @@ TEST(BinaryRecords, EncodeAndDecodeSimpleRecord)
 TEST(BinaryRecords, InitialiseRecordArrayCopy)
 {
     SETUP()
-    ThingSetReadOnlyProperty<0x800, 0x0, "Modules", std::array<ModuleRecord, 2>> records(moduleRecords.getValue());
+    ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> records(0x800, 0x0, "Modules", moduleRecords.getValue());
     ASSERT_EQ(24.2f, records[1].voltage.getValue());
     uint8_t buffer[512];
     FixedDepthThingSetBinaryEncoder encoder(buffer, sizeof(buffer));
@@ -111,7 +111,7 @@ TEST(BinaryRecords, InitialiseRecordArrayCopy)
 TEST(BinaryRecords, RecordArrayIndexing)
 {
     SETUP()
-    ThingSetReadOnlyProperty<0x800, 0x0, "Modules", std::array<ModuleRecord, 2>> records(moduleRecords.getValue());
+    ThingSetReadOnlyProperty<std::array<ModuleRecord, 2>> records(0x800, 0x0, "Modules", moduleRecords.getValue());
     ASSERT_EQ(24.2f, records[1].voltage.getValue());
     ModuleRecord *mod = &records[1];
     ASSERT_EQ(24.2f, mod->voltage.getValue());
@@ -120,7 +120,7 @@ TEST(BinaryRecords, RecordArrayIndexing)
 TEST(BinaryRecords, InitialiseRecordArrayInline)
 {
     SETUP()
-    ThingSetReadOnlyProperty<0x800, 0x0, "Modules", std::array<ModuleRecord, 1>> records = { { (ModuleRecord){
+    ThingSetReadOnlyProperty<std::array<ModuleRecord, 1>> records { 0x800, 0x0, "Modules", { (ModuleRecord){
         .voltage = 24.0f,
         .current = 10.0f,
         .error = 0,

--- a/tests/TestProperties.cpp
+++ b/tests/TestProperties.cpp
@@ -10,9 +10,9 @@ using namespace ThingSet;
 
 TEST(Properties, SimpleProperty)
 {
-    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyRead };
-    ThingSetProperty<int32_t> i32 { 0x200, 0, "i32", ThingSetAccess::anyRead };
-    ThingSetProperty<uint32_t> u32 { 0x201, 0, "u32", ThingSetAccess::anyRead };
+    ThingSetReadOnlyProperty<float> f32 { 0x100, 0, "f32" };
+    ThingSetReadOnlyProperty<int32_t> i32 { 0x200, 0, "i32" };
+    ThingSetReadOnlyProperty<uint32_t> u32 { 0x201, 0, "u32" };
 
     ThingSetNode *node;
     ASSERT_TRUE(ThingSetRegistry::findById(0x100, &node));
@@ -33,7 +33,7 @@ TEST(Properties, SimpleProperty)
 TEST(Properties, PointerProperty)
 {
     float rf32 = 1.0;
-    ThingSetProperty prf32 { 0x101, 0, "rf32", ThingSetAccess::anyRead, &rf32 };
+    ThingSetReadOnlyProperty prf32 { 0x101, 0, "rf32", &rf32 };
     ASSERT_EQ("f32", prf32.getType());
     prf32 = 1.5;
     ASSERT_EQ(1.5, rf32);

--- a/tests/TestProperties.cpp
+++ b/tests/TestProperties.cpp
@@ -10,9 +10,9 @@ using namespace ThingSet;
 
 TEST(Properties, SimpleProperty)
 {
-    ThingSetReadOnlyProperty<0x100, 0, "f32", float> f32;
-    ThingSetReadOnlyProperty<0x200, 0, "i32", int32_t> i32;
-    ThingSetReadOnlyProperty<0x201, 0, "u32", uint32_t> u32;
+    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyRead };
+    ThingSetProperty<int32_t> i32 { 0x200, 0, "i32", ThingSetAccess::anyRead };
+    ThingSetProperty<uint32_t> u32 { 0x201, 0, "u32", ThingSetAccess::anyRead };
 
     ThingSetNode *node;
     ASSERT_TRUE(ThingSetRegistry::findById(0x100, &node));
@@ -33,7 +33,7 @@ TEST(Properties, SimpleProperty)
 TEST(Properties, PointerProperty)
 {
     float rf32 = 1.0;
-    ThingSetReadOnlyProperty<0x101, 0, "rf32", float *> prf32(&rf32);
+    ThingSetProperty prf32 { 0x101, 0, "rf32", ThingSetAccess::anyRead, &rf32 };
     ASSERT_EQ("f32", prf32.getType());
     prf32 = 1.5;
     ASSERT_EQ(1.5, rf32);

--- a/tests/TestSocketIpClientServer.cpp
+++ b/tests/TestSocketIpClientServer.cpp
@@ -20,7 +20,7 @@ static std::array<uint8_t, 1024> txBuffer;
 #define SOCKET_TEST(Name, Body) \
 TEST(SocketIpClientServer, Name) \
 { \
-    ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24; \
+    ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f }; \
     ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; }); \
 \
     ThingSetSocketServerTransport serverTransport; \

--- a/tests/TestSubsets.cpp
+++ b/tests/TestSubsets.cpp
@@ -10,9 +10,9 @@ using namespace ThingSet;
 
 TEST(Subsets, Collection)
 {
-    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyRead, Subset::live };
-    ThingSetProperty<int32_t> i32 { 0x200, 0, "i32", ThingSetAccess::anyRead };
-    ThingSetProperty<uint32_t> u32 { 0x201, 0, "u32", ThingSetAccess::anyRead, Subset::live };
+    ThingSetReadOnlyProperty<float, Subset::live> f32 { 0x100, 0, "f32" };
+    ThingSetReadOnlyProperty<int32_t> i32 { 0x200, 0, "i32" };
+    ThingSetReadOnlyProperty<uint32_t, Subset::live> u32 { 0x201, 0, "u32" };
 
     size_t count = 0;
     std::array<const char *, 2> names = {
@@ -29,7 +29,7 @@ TEST(Subsets, Collection)
 
 TEST(Subsets, Multiple)
 {
-    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyReadWrite, Subset::live | Subset::persisted };
+    ThingSetReadWriteProperty<float, Subset::live | Subset::persisted> f32 { 0x100, 0, "f32" };
 
     size_t count = 0;
     for (auto node : ThingSetRegistry::nodesInSubset(Subset::live))

--- a/tests/TestSubsets.cpp
+++ b/tests/TestSubsets.cpp
@@ -10,9 +10,9 @@ using namespace ThingSet;
 
 TEST(Subsets, Collection)
 {
-    ThingSetReadOnlyProperty<0x100, 0, "f32", float, Subset::live> f32;
-    ThingSetReadOnlyProperty<0x200, 0, "i32", int32_t> i32;
-    ThingSetReadOnlyProperty<0x201, 0, "u32", uint32_t, Subset::live> u32;
+    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyRead, Subset::live };
+    ThingSetProperty<int32_t> i32 { 0x200, 0, "i32", ThingSetAccess::anyRead };
+    ThingSetProperty<uint32_t> u32 { 0x201, 0, "u32", ThingSetAccess::anyRead, Subset::live };
 
     size_t count = 0;
     std::array<const char *, 2> names = {
@@ -29,7 +29,7 @@ TEST(Subsets, Collection)
 
 TEST(Subsets, Multiple)
 {
-    ThingSetReadWriteProperty<0x100, 0, "f32", float, Subset::live | Subset::persisted> f32 = 1.0;
+    ThingSetProperty<float> f32 { 0x100, 0, "f32", ThingSetAccess::anyReadWrite, Subset::live | Subset::persisted };
 
     size_t count = 0;
     for (auto node : ThingSetRegistry::nodesInSubset(Subset::live))

--- a/tests/TestTextDecoder.cpp
+++ b/tests/TestTextDecoder.cpp
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "thingset++/ThingSetTextDecoder.hpp"
-#include "thingset++/ThingSetProperty.hpp"
+#include "thingset++/ThingSetRecordMember.hpp"
 #include "gtest/gtest.h"
 
 using namespace ThingSet;
 
 struct StructTest
 {
-    ThingSetReadOnlyProperty<0x701, 0x700, "nodeID", std::string> nodeId;
-    ThingSetReadOnlyProperty<0x702, 0x700, "three", std::array<float, 3>> three;
-    ThingSetReadOnlyProperty<0x703, 0x700, "canAddr", uint8_t> canAddr;
+    ThingSetReadOnlyRecordMember<0x701, 0x700, "nodeID", std::string> nodeId;
+    ThingSetReadOnlyRecordMember<0x702, 0x700, "three", std::array<float, 3>> three;
+    ThingSetReadOnlyRecordMember<0x703, 0x700, "canAddr", uint8_t> canAddr;
 };
 
 TEST(TextDecoder, DecodeStdString)

--- a/tests/TestTextEncodingRecords.cpp
+++ b/tests/TestTextEncodingRecords.cpp
@@ -4,24 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "thingset++/ThingSet.hpp"
+#include "thingset++/ThingSetRecordMember.hpp"
 #include "gtest/gtest.h"
 
 using namespace ThingSet;
 
 struct SupercellRecord
 {
-    ThingSetReadOnlyProperty<0x611, 0x610, "soc", float> soc;
-    ThingSetReadOnlyProperty<0x612, 0x610, "soh", float> soh;
+    ThingSetReadOnlyRecordMember<0x611, 0x610, "soc", float> soc;
+    ThingSetReadOnlyRecordMember<0x612, 0x610, "soh", float> soh;
 };
 
 struct ModuleRecord
 {
     bool ignored; // this field will be ignored by the encoder and decoder
-    ThingSetReadOnlyProperty<0x601, 0x600, "voltage", float> voltage;
-    ThingSetReadOnlyProperty<0x602, 0x600, "current", float> current;
-    ThingSetReadOnlyProperty<0x603, 0x600, "error", uint64_t> error;
-    ThingSetReadOnlyProperty<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
-    ThingSetReadOnlyProperty<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
+    ThingSetReadOnlyRecordMember<0x601, 0x600, "voltage", float> voltage;
+    ThingSetReadOnlyRecordMember<0x602, 0x600, "current", float> current;
+    ThingSetReadOnlyRecordMember<0x603, 0x600, "error", uint64_t> error;
+    ThingSetReadOnlyRecordMember<0x604, 0x600, "cellVoltages", std::array<float, 6>> cellVoltages;
+    ThingSetReadOnlyRecordMember<0x609, 0x600, "supercells", std::array<SupercellRecord, 6>> supercells;
 };
 
 #define ASSERT_BUFFER_EQ(expected, actual, actual_len)                                                                 \
@@ -31,7 +32,7 @@ struct ModuleRecord
     }
 
 #define SETUP()                                                                                                        \
-    ThingSetReadOnlyProperty<0x610, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords = {                       \
+    ThingSetReadOnlyRecordMember<0x610, 0, "Modules", std::array<ModuleRecord, 2>> moduleRecords = {                   \
         { (ModuleRecord){                                                                                              \
               .voltage = 24.0f,                                                                                        \
               .current = 10.0f,                                                                                        \
@@ -111,7 +112,7 @@ TEST(TextRecords,
 TEST(TextRecords, InitialiseRecordArrayCopy)
 {
     SETUP()
-    ThingSetReadOnlyProperty<0x800, 0x0, "Modules", std::array<ModuleRecord, 2>> records(moduleRecords.getValue());
+    ThingSetReadOnlyRecordMember<0x800, 0x0, "Modules", std::array<ModuleRecord, 2>> records(moduleRecords.getValue());
     ASSERT_EQ(24.2f, records[1].voltage.getValue());
     char buffer[TEXT_ENCODER_BUFFER_SIZE];
     size_t size = sizeof(buffer);
@@ -131,7 +132,7 @@ TEST(TextRecords, InitialiseRecordArrayCopy)
 TEST(TextRecords, InitialiseRecordArrayInline)
 {
     SETUP()
-    ThingSetReadOnlyProperty<0x800, 0x0, "Modules", std::array<ModuleRecord, 1>> records = { { (ModuleRecord){
+    ThingSetReadOnlyRecordMember<0x800, 0x0, "Modules", std::array<ModuleRecord, 1>> records = { { (ModuleRecord){
         .voltage = 24.0f,
         .current = 10.0f,
         .error = 0,

--- a/tests/zephyr/src/main.cpp
+++ b/tests/zephyr/src/main.cpp
@@ -28,7 +28,7 @@ ThingSetZephyrCanInterface clientInterface(canDevice);
 ThingSetZephyrCanServerTransport serverTransport(serverInterface, serverRxBuffer, serverTxBuffer);
 ThingSetZephyrCanClientTransport clientTransport(clientInterface, 0x01, clientRxBuffer, clientTxBuffer);
 
-ThingSetReadWriteProperty<0x300, 0, "totalVoltage", float> totalVoltage = 24;
+ThingSetReadWriteProperty<float> totalVoltage { 0x300, 0, "totalVoltage", 24.0f };
 
 ThingSetUserFunction<0x1000, 0x0, "xAddNumber", int, int, int> doSomething([](auto x, auto y) { return x + y; });
 


### PR DESCRIPTION
* split out properties and record members, removing identifier template parameters from the former to significantly reduce code size
* reduce inheritance (at the cost of repetitiveness) to reduce code size (fewer vtables)