### PR TITLE
Support decoding of custom types in function args

### DIFF
--- a/include/thingset++/ThingSetBinaryDecoder.hpp
+++ b/include/thingset++/ThingSetBinaryDecoder.hpp
@@ -77,6 +77,7 @@ public:
     bool decodeNull() override;
     bool decodeListStart() override;
     bool decodeListEnd() override;
+    bool decodeBytes(uint8_t *buffer, size_t capacity, size_t &size) override;
 
     ThingSetEncodedNodeType peekType() override;
     bool skip() override;

--- a/include/thingset++/ThingSetFunction.hpp
+++ b/include/thingset++/ThingSetFunction.hpp
@@ -22,16 +22,16 @@ public:
     virtual bool invoke(ThingSetDecoder &decoder, ThingSetEncoder &encoder) = 0;
 };
 
-template <typename Result, typename... Args>
-static bool invoke(std::function<Result(Args...)> &function, std::tuple<Args...> &arguments,
+template <typename Result, typename... Args, typename... Values>
+static bool invoke(std::function<Result(Args...)> &function, std::tuple<Values...> &arguments,
                    ThingSetEncoder &encoder)
 {
     Result result = std::apply(function, arguments);
     return encoder.encode(result);
 }
 
-template <typename... Args>
-static bool invoke(std::function<void(Args...)> &function, std::tuple<Args...> &arguments,
+template <typename... Args, typename... Values>
+static bool invoke(std::function<void(Args...)> &function, std::tuple<Values...> &arguments,
                    ThingSetEncoder &encoder)
 {
     std::apply(function, arguments);
@@ -90,7 +90,7 @@ private:
     /// @brief A tuple containing ThingSet nodes which represent the parameters to the function.
     _ArgumentTransformer<_ParameterBuilder, sizeof...(Args)>::type _parameters;
     /// @brief The storage into which function arguments are decoded before invocation.
-    std::tuple<Args...> _arguments;
+    std::tuple<std::remove_cvref_t<Args>...> _arguments;
 
 public:
     ThingSetFunction(std::function<Result(Args...)> function)

--- a/include/thingset++/ThingSetTextDecoder.hpp
+++ b/include/thingset++/ThingSetTextDecoder.hpp
@@ -57,6 +57,7 @@ public:
     bool decodeNull() override;
     bool decodeListStart() override;
     bool decodeListEnd() override;
+    bool decodeBytes(uint8_t *buffer, size_t capacity, size_t &size) override;
     bool skip() override;
 
     ThingSetEncodedNodeType peekType() override;

--- a/src/ThingSetBinaryDecoder.cpp
+++ b/src/ThingSetBinaryDecoder.cpp
@@ -149,6 +149,17 @@ bool ThingSetBinaryDecoder::decodeListEnd()
     return zcbor_list_end_decode(getState());
 }
 
+bool ThingSetBinaryDecoder::decodeBytes(uint8_t *buffer, size_t capacity, size_t &size)
+{
+    zcbor_string result;
+    if (zcbor_bstr_decode(getState(), &result) && result.len <= capacity) {
+        memcpy(buffer, result.value, result.len);
+        size = result.len;
+        return true;
+    }
+    return false;
+}
+
 bool ThingSetBinaryDecoder::decodeMapStart()
 {
     return zcbor_map_start_decode(getState());

--- a/src/ThingSetTextDecoder.cpp
+++ b/src/ThingSetTextDecoder.cpp
@@ -160,6 +160,12 @@ bool ThingSetTextDecoder::decodeListEnd()
     return false;
 }
 
+bool ThingSetTextDecoder::decodeBytes(uint8_t *, size_t, size_t &)
+{
+    // TODO: I guess this would be a base64-encoded string or something
+    return false;
+}
+
 bool ThingSetTextDecoder::decodeMapStart()
 {
     return expectType(JSMN_OBJECT, nullptr);


### PR DESCRIPTION
- support decoding of custom types in function args
- add a test with an example dynamically-sized (but statically allocated) buffer