### PR TITLE
Only set _isBound to true after successful address claim

### DIFF
--- a/src/can/zephyr/ThingSetZephyrCanInterface.cpp
+++ b/src/can/zephyr/ThingSetZephyrCanInterface.cpp
@@ -207,9 +207,10 @@ bool ThingSetZephyrCanInterface::bind(uint8_t nodeAddress)
         }
 
         LOG_INFO("CAN device %s bound to address 0x%x", _canDevice->name, _nodeAddress);
+        _isBound = true;
     }
-    _isBound = true;
-    return true;
+
+    return _isBound;
 }
 
 } // namespace ThingSet::Can::Zephyr


### PR DESCRIPTION
So that `bind()` essentially becomes idempotent and can be used to check the state from a separate thread, ISR, etc, without the need for an additional getter func