### PR TITLE
Account for header length when zeroing _buffer

### DIFF
--- a/include/thingset++/StreamingThingSetBinaryEncoder.hpp
+++ b/include/thingset++/StreamingThingSetBinaryEncoder.hpp
@@ -53,8 +53,8 @@ public:
             }
             currentLength = _state->payload - &_buffer[headerSize];
         }
-        size_t remainder = _buffer.size() - currentLength;
-        memset(&_buffer[currentLength], 0, remainder);
+        size_t remainder = _buffer.size() - headerSize - currentLength;
+        memset(&_buffer[headerSize + currentLength], 0, remainder);
         bool result = write(currentLength, true);
         _exportedLength += currentLength;
         return result;


### PR DESCRIPTION
`StreamingThingSetBinaryEncoder::flush()` zeroes the buffer after the encoded data, but the memset offset didn't account for the header size. `currentLength` is relative to `&_buffer[headerSize]`, but the memset started at `&_buffer[currentLength]`, overwriting the last headerSize bytes of the encoded CBOR payload with zeros.

This caused the final property in every UDP report to have its ID corrupted (e.g. 0x0E05 → 0x0E00).

To fix we offset the memset by `headerSize` and adjust the remainder length accordingly.

I.e., the last bytes of this payload are `0E 00 00`:

```
0x0080:  1903 0100 190e 0400 190e 0000            ............
```

But should be (and are, after this fix) `0E 05 01`:

```
0x0080:  1903 0100 190e 0400 190e 0501            ............
```

Presumably this also affects the CAN transport as this sits above that but I have not verified this.