### PR TITLE
Fix claiming same address

### DIFF
--- a/src/can/zephyr/ThingSetZephyrCanInterface.cpp
+++ b/src/can/zephyr/ThingSetZephyrCanInterface.cpp
@@ -62,6 +62,11 @@ void ThingSetZephyrCanInterface::onAddressClaimReceived(const device *dev, can_f
 {
     ThingSetZephyrCanInterface *self = (ThingSetZephyrCanInterface *)arg;
     auto canId = CanID::create(frame->id);
+
+    if (memcmp(frame->data, Eui::getArray().data(), Eui::getArray().size()) == 0) {
+        return;
+    }
+
     if (self->_nodeAddress == canId.getSource()) {
         k_event_post(&self->_events, AddressClaimEvent::alreadyUsed);
     }

--- a/src/can/zephyr/ThingSetZephyrCanInterface.cpp
+++ b/src/can/zephyr/ThingSetZephyrCanInterface.cpp
@@ -83,7 +83,7 @@ void ThingSetZephyrCanInterface::onAnyAddressDiscoverReceived(const device *dev,
 {
     ThingSetZephyrCanInterface *self = (ThingSetZephyrCanInterface *)arg;
     auto canId = CanID::create(frame->id);
-    if (self->_nodeAddress == canId.getSource()) {
+    if (self->_nodeAddress == canId.getTarget()) {
         /* received a discovery frame for an address we are already in the process of claiming */
         k_work_submit(&self->_addressClaimWork.work);
     }
@@ -174,6 +174,7 @@ bool ThingSetZephyrCanInterface::bind(uint8_t nodeAddress)
                 uint8_t oldNodeAddress = _nodeAddress;
                 _nodeAddress = CanID::minAddress + sys_rand32_get() % ((CanID::maxAddress + 1) - CanID::minAddress);
                 LOG_WARN("Node addr 0x%.2X already in use, trying 0x%.2X", oldNodeAddress, _nodeAddress);
+                k_sleep(K_MSEC(100));
             }
             else {
                 can_bus_err_cnt err_cnt_before;


### PR DESCRIPTION
Adds a backoff to stop repeated address claims from spamming the bus. We ran a test where there were 5 modules and only 4 available addresses. We expected 4 modules to claim their addresses and the 5th to just continually try to grab addresses while the other 4 boards defended the 4 available addresses. In practice, it seems that the claims were happening so quickly that sometimes boards were not defending their claims in time and the 5th module would then claim this address and two boards would continue to fight over it. We have occasionally seen two modules coming up on the same address in practice and we believe this to be the source of the issue.

Also fixes a minor issue where we were checking the source address in onAnyAddressDiscoverReceived. Since this callback is used when we are claiming but have not yet successfully claimed an address, getSource will return the anonymous address 0xFE and getTarget will return the address that we are trying to claim which is what we need here.