### PR TITLE
Optionally truncate displayed arrays when _depth != 0 in text mode

### DIFF
--- a/include/thingset++/ThingSetEncoder.hpp
+++ b/include/thingset++/ThingSetEncoder.hpp
@@ -211,9 +211,14 @@ public:
 
     template <typename T> bool encode(const T *value, const size_t &size)
     {
+        const size_t n = renderedListLength(size);
         bool result = encodeListStart(size);
-        for (size_t i = 0; i < size; i++) {
+        for (size_t i = 0; i < n; i++) {
             result &= this->encode(value[i]) && this->encodeListSeparator();
+        }
+        if (n < size) {
+            // Trailing separator is stripped by encodeListEnd()
+            result &= encodeTruncationMarker() && this->encodeListSeparator();
         }
         return result && encodeListEnd(size);
     }
@@ -228,6 +233,22 @@ protected:
     virtual bool encodeListSeparator() = 0;
     virtual bool encodeKeyValuePairSeparator() = 0;
     virtual bool encodeKeysAsIds() const = 0;
+
+    /// @brief Hook for encoders that want to render fewer elements than an
+    /// array actually contains (e.g. for human-facing text output). Return the
+    /// number of elements to actually emit; values less than `size` cause the
+    /// truncation marker to be appended after the loop
+    virtual size_t renderedListLength(const size_t &size)
+    {
+        return size;
+    }
+
+    /// @brief Hook for encoders to append a truncation marker element (e.g. a
+    /// `"..."` string) when @ref renderedListLength clamps the emitted count
+    virtual bool encodeTruncationMarker()
+    {
+        return true;
+    }
 
 private:
     inline bool encodeAndShift()

--- a/include/thingset++/ThingSetTextEncoder.hpp
+++ b/include/thingset++/ThingSetTextEncoder.hpp
@@ -35,6 +35,7 @@ public:
     }
 
     using ThingSetEncoder::encode;
+
     bool encode(const std::string_view &value) override;
     bool encode(std::string_view &value) override;
     bool encode(const std::string &value) override;
@@ -103,6 +104,8 @@ protected:
     bool encodeListSeparator() override;
     bool encodeKeyValuePairSeparator() override;
     bool encodeKeysAsIds() const override;
+    size_t renderedListLength(const size_t &size) override;
+    bool encodeTruncationMarker() override;
 
 private:
     /// @brief Determine the length of the value as a string

--- a/src/ThingSetTextEncoder.cpp
+++ b/src/ThingSetTextEncoder.cpp
@@ -225,4 +225,22 @@ bool ThingSetTextEncoder::encodeKeysAsIds() const
     return false;
 }
 
+size_t ThingSetTextEncoder::renderedListLength(const size_t &size)
+{
+#if defined(CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX) && CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX > 0
+    // Only truncate when this array is nested inside a bigger response.
+    // If _depth == 0 the array IS the response (direct query, e.g. ?cellVoltages)
+    // and the user wants to see it in full
+    if (_depth > 0 && size > (size_t)CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX) {
+        return CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX;
+    }
+#endif
+    return size;
+}
+
+bool ThingSetTextEncoder::encodeTruncationMarker()
+{
+    return encode("...");
+}
+
 } // namespace ThingSet

--- a/src/ThingSetTextEncoder.cpp
+++ b/src/ThingSetTextEncoder.cpp
@@ -248,7 +248,10 @@ size_t ThingSetTextEncoder::renderedListLength(const size_t &size)
 
 bool ThingSetTextEncoder::encodeTruncationMarker()
 {
-    return encode("...");
+    // Emit the ellipsis bare (no surrounding quotes). The truncated output is
+    // no longer strict JSON, but this encoder's truncation mode is a
+    // human-facing shell convenience — readability wins over parser-friendliness.
+    return append('.') && append('.') && append('.');
 }
 
 } // namespace ThingSet

--- a/tests/TestTextEncoder.cpp
+++ b/tests/TestTextEncoder.cpp
@@ -416,6 +416,59 @@ TEST(TextEncoder, EncodeList)
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 
+/// Fixed-limit encoder used to exercise renderedListLength/encodeTruncationMarker
+/// without relying on a compile-time CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX.
+/// Always caps lists at `_limit` elements; callers can also opt out of the
+/// top-level "don't truncate direct queries" behaviour by preset-ing _depth > 0.
+class TruncatingTextEncoder : public ThingSetTextEncoder
+{
+public:
+    size_t _limit;
+    using ThingSetTextEncoder::ThingSetTextEncoder;
+    TruncatingTextEncoder(char *buffer, size_t size, size_t limit) : ThingSetTextEncoder(buffer, size), _limit(limit) {}
+protected:
+    size_t renderedListLength(const size_t &size) override
+    {
+        return size > _limit ? _limit : size;
+    }
+    bool encodeTruncationMarker() override
+    {
+        return encode("...");
+    }
+};
+
+TEST(TextEncoder, TruncatesLongArrayWithMarker)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    TruncatingTextEncoder encoder(buffer, sizeof(buffer), /*limit=*/3);
+    std::array<int, 8> i = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    encoder.encode(i);
+    const char *expected = "[1,2,3,\"...\"]";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, ArrayAtLimitIsNotTruncated)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    TruncatingTextEncoder encoder(buffer, sizeof(buffer), /*limit=*/3);
+    std::array<int, 3> i = { 1, 2, 3 };
+    encoder.encode(i);
+    const char *expected = "[1,2,3]";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, BaseEncoderDoesNotTruncate)
+{
+    // Default ThingSetTextEncoder's renderedListLength returns size unchanged
+    // when CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX isn't defined (or is 0),
+    // so long arrays render in full.
+    SETUP(TEXT_ENCODER_BUFFER_SIZE)
+    std::array<int, 6> i = { 1, 2, 3, 4, 5, 6 };
+    encoder.encode(i);
+    const char *expected = "[1,2,3,4,5,6]";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
 TEST(TextEncoder, TestBoundaryEncode)
 {
     SETUP(1) // make buffer of size 1 to ensure value cannot fit

--- a/tests/TestTextEncoder.cpp
+++ b/tests/TestTextEncoder.cpp
@@ -431,10 +431,6 @@ protected:
     {
         return size > _limit ? _limit : size;
     }
-    bool encodeTruncationMarker() override
-    {
-        return encode("...");
-    }
 };
 
 TEST(TextEncoder, TruncatesLongArrayWithMarker)
@@ -443,7 +439,7 @@ TEST(TextEncoder, TruncatesLongArrayWithMarker)
     TruncatingTextEncoder encoder(buffer, sizeof(buffer), /*limit=*/3);
     std::array<int, 8> i = { 1, 2, 3, 4, 5, 6, 7, 8 };
     encoder.encode(i);
-    const char *expected = "[1,2,3,\"...\"]";
+    const char *expected = "[1,2,3,...]";
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -17,6 +17,16 @@ config THINGSET_PLUS_PLUS_PROTOCOL_TEXT
 	bool "Enable text mode"
 	default true
 
+config THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX
+	int "Max array elements to render in text mode (0 = unlimited)"
+	depends on THINGSET_PLUS_PLUS_PROTOCOL_TEXT
+	range 0 65535
+	default 0
+	help
+		When non-zero, arrays longer than this value are truncated in
+		text-mode output: the first N elements are rendered followed by
+		a literal "..." marker
+
 config THINGSET_PLUS_PLUS_ENHANCED_REPORTING
 	bool "Enable enhanced reporting"
 	default false


### PR DESCRIPTION
As it says on the tin, example:

```
uart:~$ thingset ?HMCU
:85 {"testArray":[1,2,3,4,"..."],"rIpAddr":"192.168.1.1"}
uart:~$ thingset ?HMCU/testArray
:85 [1,2,3,4,5,6,7,8,9,10]
```