### PR TITLE
Render groups when emitting in text mode

### DIFF
--- a/include/thingset++/ThingSetEncoder.hpp
+++ b/include/thingset++/ThingSetEncoder.hpp
@@ -22,6 +22,38 @@ class ThingSetNode;
 template<typename T>
 concept IsEncodable = std::is_base_of_v<ThingSetEncodable, T>;
 
+enum class TextEncoderOptions : uint32_t
+{
+    none             = 0,
+    /// Truncate long arrays nested inside a larger response, replacing
+    /// the omitted tail with "..." (see ThingSetTextEncoder::renderedListLength).
+    abbreviateArrays = 1U << 0,
+    /// When a group is nested inside a larger response, emit only its
+    /// child groups (structure) and suppress leaf values. A direct
+    /// query against the group itself still renders fully
+    outlineGroups    = 1U << 1,
+
+    displayFriendly  = abbreviateArrays | outlineGroups,
+};
+
+constexpr TextEncoderOptions operator|(TextEncoderOptions a, TextEncoderOptions b)
+{
+    return static_cast<TextEncoderOptions>(
+        static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+
+constexpr TextEncoderOptions operator&(TextEncoderOptions a, TextEncoderOptions b)
+{
+    return static_cast<TextEncoderOptions>(
+        static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+
+/// @brief True if any of the bits in ``flag`` are set in ``value``.
+constexpr bool any(TextEncoderOptions value, TextEncoderOptions flag)
+{
+    return static_cast<uint32_t>(value & flag) != 0;
+}
+
 /// @brief Encoder base class for ThingSet.
 class ThingSetEncoder
 {
@@ -230,10 +262,10 @@ public:
     /// choose the right key form when emitting nested maps
     virtual bool encodeKeysAsIds() const = 0;
 
-    /// @brief Hook that lets encoders request groups be rendered as a skeleton
-    /// (sub-groups only, leaf values suppressed) when they appear nested
-    /// inside a larger response
-    virtual bool renderGroupAsSkeleton() const
+    /// @brief Hook that lets encoders request groups be rendered as an
+    /// outline (sub-groups only, leaf values suppressed) when they appear
+    /// nested inside a larger response
+    virtual bool renderGroupAsOutline() const
     {
         return false;
     }

--- a/include/thingset++/ThingSetEncoder.hpp
+++ b/include/thingset++/ThingSetEncoder.hpp
@@ -224,10 +224,23 @@ public:
         return encodeListStart(count) && encodeAndShift(args...) && encodeListEnd(count);
     }
 
+    /// @brief Whether this encoder emits map keys as numeric IDs (true, as in
+    /// binary formats) or as names (false, as in text/JSON). Exposed publicly
+    /// so that composite encodable implementations (e.g. ThingSetGroup) can
+    /// choose the right key form when emitting nested maps
+    virtual bool encodeKeysAsIds() const = 0;
+
+    /// @brief Hook that lets encoders request groups be rendered as a skeleton
+    /// (sub-groups only, leaf values suppressed) when they appear nested
+    /// inside a larger response
+    virtual bool renderGroupAsSkeleton() const
+    {
+        return false;
+    }
+
 protected:
     virtual bool encodeListSeparator() = 0;
     virtual bool encodeKeyValuePairSeparator() = 0;
-    virtual bool encodeKeysAsIds() const = 0;
 
 private:
     inline bool encodeAndShift()

--- a/include/thingset++/ThingSetGroup.hpp
+++ b/include/thingset++/ThingSetGroup.hpp
@@ -59,26 +59,25 @@ public:
 
     /// @brief Emit the group's encodable children as a nested map. This lets
     /// groups appear as values in their parent's rendering (e.g. `?` at root
-    /// now returns `{"GroupA":{...},"GroupB":{...},...}` instead of skipping
-    /// groups entirely). Nesting recurses naturally because encodable children
-    /// that are themselves groups dispatch to this same override
+    /// returns `{"GroupA":{...},"GroupB":{...},...}` instead of skipping
+    /// groups entirely)
     ///
-    /// If the encoder requests skeleton rendering (see
-    /// ThingSetEncoder::renderGroupAsSkeleton), only child groups are emitted;
+    /// If the encoder requests outline rendering (see
+    /// ThingSetEncoder::renderGroupAsOutline), only child groups are emitted;
     /// leaf values (properties, records, arrays) are suppressed
     bool encode(ThingSetEncoder &encoder) const override
     {
         // const_cast: ThingSetParentNode::begin/end are non-const, but we only
         // read the child list here
         auto *self = const_cast<ThingSetGroup *>(this);
-        const bool skeleton = encoder.renderGroupAsSkeleton();
+        const bool outline = encoder.renderGroupAsOutline();
         void *target;
 
         auto shouldInclude = [&](ThingSetNode *child) {
             if (!child->tryCastTo(ThingSetNodeType::encodable, &target)) {
                 return false;
             }
-            if (skeleton && !child->tryCastTo(ThingSetNodeType::group, &target)) {
+            if (outline && !child->tryCastTo(ThingSetNodeType::group, &target)) {
                 return false;
             }
             return true;

--- a/include/thingset++/ThingSetGroup.hpp
+++ b/include/thingset++/ThingSetGroup.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "thingset++/IdentifiableThingSetNode.hpp"
+#include "thingset++/ThingSetEncoder.hpp"
 #include "thingset++/ThingSetParentNode.hpp"
 
 namespace ThingSet {
@@ -17,7 +18,7 @@ static inline bool defaultCallback(ThingSetNode *, ThingSetCallbackReason)
 }
 
 template <uint16_t Id, uint16_t ParentId, StringLiteral Name>
-class ThingSetGroup : public IdentifiableThingSetParentNode<Id, ParentId, Name>
+class ThingSetGroup : public IdentifiableThingSetParentNode<Id, ParentId, Name>, public ThingSetEncodable
 {
 private:
     std::function<bool(ThingSetNode *, ThingSetCallbackReason)> _callback;
@@ -40,6 +41,72 @@ public:
     bool invokeCallback(ThingSetNode *node, ThingSetCallbackReason reason) const override
     {
         return _callback(node, reason);
+    }
+
+    bool tryCastTo(ThingSetNodeType type, void **target) override
+    {
+        if (type == ThingSetNodeType::encodable) {
+            *target = static_cast<ThingSetEncodable *>(this);
+            return true;
+        }
+        if (type == ThingSetNodeType::group) {
+            // Marker cast so callers can distinguish groups from other
+            // hasChildren nodes (e.g. records)
+            return true;
+        }
+        return IdentifiableThingSetParentNode<Id, ParentId, Name>::tryCastTo(type, target);
+    }
+
+    /// @brief Emit the group's encodable children as a nested map. This lets
+    /// groups appear as values in their parent's rendering (e.g. `?` at root
+    /// now returns `{"GroupA":{...},"GroupB":{...},...}` instead of skipping
+    /// groups entirely). Nesting recurses naturally because encodable children
+    /// that are themselves groups dispatch to this same override
+    ///
+    /// If the encoder requests skeleton rendering (see
+    /// ThingSetEncoder::renderGroupAsSkeleton), only child groups are emitted;
+    /// leaf values (properties, records, arrays) are suppressed
+    bool encode(ThingSetEncoder &encoder) const override
+    {
+        // const_cast: ThingSetParentNode::begin/end are non-const, but we only
+        // read the child list here
+        auto *self = const_cast<ThingSetGroup *>(this);
+        const bool skeleton = encoder.renderGroupAsSkeleton();
+        void *target;
+
+        auto shouldInclude = [&](ThingSetNode *child) {
+            if (!child->tryCastTo(ThingSetNodeType::encodable, &target)) {
+                return false;
+            }
+            if (skeleton && !child->tryCastTo(ThingSetNodeType::group, &target)) {
+                return false;
+            }
+            return true;
+        };
+
+        size_t count = 0;
+        for (ThingSetNode *child : *self) {
+            if (shouldInclude(child)) {
+                count++;
+            }
+        }
+        if (!encoder.encodeMapStart(count)) {
+            return false;
+        }
+        for (ThingSetNode *child : *self) {
+            if (!shouldInclude(child)) {
+                continue;
+            }
+            child->tryCastTo(ThingSetNodeType::encodable, &target);
+            ThingSetEncodable *encodable = reinterpret_cast<ThingSetEncodable *>(target);
+            bool ok = encoder.encodeKeysAsIds()
+                ? encoder.encode(std::make_pair(child->getId(), encodable))
+                : encoder.encode(std::make_pair(child->getName(), encodable));
+            if (!ok) {
+                return false;
+            }
+        }
+        return encoder.encodeMapEnd(count);
     }
 };
 

--- a/include/thingset++/ThingSetRequestContext.hpp
+++ b/include/thingset++/ThingSetRequestContext.hpp
@@ -142,7 +142,9 @@ private:
     DefaultFixedSizeThingSetTextDecoder _decoder;
 
 public:
-    ThingSetTextRequestContext(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize);
+    ThingSetTextRequestContext(uint8_t *request, size_t requestLen,
+                               uint8_t *response, size_t responseSize,
+                               TextEncoderOptions opts = TextEncoderOptions::none);
 
     inline ThingSetEncoder &encoder() override {
         return _encoder;

--- a/include/thingset++/ThingSetServer.hpp
+++ b/include/thingset++/ThingSetServer.hpp
@@ -30,12 +30,20 @@ class _ThingSetServer
 private:
     ThingSetAccess _access;
     ThingSetForwarder *_forwarder;
+#ifdef ENABLE_TEXT_MODE
+    TextEncoderOptions _textOpts = TextEncoderOptions::none;
+#endif // ENABLE_TEXT_MODE
 
 protected:
     _ThingSetServer(ThingSetForwarder *forwarder);
 
 public:
     virtual bool listen() = 0;
+
+#ifdef ENABLE_TEXT_MODE
+    void setTextOptions(TextEncoderOptions opts) { _textOpts = opts; }
+    TextEncoderOptions getTextOptions() const { return _textOpts; }
+#endif // ENABLE_TEXT_MODE
 
 private:
     int handleGet(ThingSetRequestContext &context);

--- a/include/thingset++/ThingSetTextEncoder.hpp
+++ b/include/thingset++/ThingSetTextEncoder.hpp
@@ -20,14 +20,22 @@ private: // todo repeated label?
     size_t _responseSize;
     size_t _responsePosition;
     uint8_t _depth;
+    TextEncoderOptions _opts;
 
 public:
     template <size_t Size>
-    ThingSetTextEncoder(std::array<char, Size> buffer) : ThingSetTextEncoder(buffer.data(), buffer.size())
+    ThingSetTextEncoder(std::array<char, Size> buffer,
+                        TextEncoderOptions opts = TextEncoderOptions::none)
+        : ThingSetTextEncoder(buffer.data(), buffer.size(), opts)
     {}
-    ThingSetTextEncoder(char *buffer, size_t size)
-        : _responseBuffer(buffer), _responseSize(size), _responsePosition(0), _depth(0)
+    ThingSetTextEncoder(char *buffer, size_t size,
+                        TextEncoderOptions opts = TextEncoderOptions::none)
+        : _responseBuffer(buffer), _responseSize(size), _responsePosition(0),
+          _depth(0), _opts(opts)
     {}
+
+    void setOptions(TextEncoderOptions opts) { _opts = opts; }
+    TextEncoderOptions getOptions() const { return _opts; }
 
     size_t getEncodedLength() const override
     {
@@ -100,7 +108,7 @@ public:
     bool encodeBytes(const uint8_t *buffer, const size_t &size) override;
 
     bool encodeKeysAsIds() const override;
-    bool renderGroupAsSkeleton() const override;
+    bool renderGroupAsOutline() const override;
 
 protected:
     bool encodeListSeparator() override;

--- a/include/thingset++/ThingSetTextEncoder.hpp
+++ b/include/thingset++/ThingSetTextEncoder.hpp
@@ -99,10 +99,12 @@ public:
     /// @return True if encoding succeeded, otherwise false.
     bool encodeBytes(const uint8_t *buffer, const size_t &size) override;
 
+    bool encodeKeysAsIds() const override;
+    bool renderGroupAsSkeleton() const override;
+
 protected:
     bool encodeListSeparator() override;
     bool encodeKeyValuePairSeparator() override;
-    bool encodeKeysAsIds() const override;
 
 private:
     /// @brief Determine the length of the value as a string

--- a/include/thingset++/zephyr/ThingSetZephyrShellServerTransport.hpp
+++ b/include/thingset++/zephyr/ThingSetZephyrShellServerTransport.hpp
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include "thingset++/ThingSetEncoder.hpp"
 #include "thingset++/ThingSetServerTransport.hpp"
 #include "thingset++/zephyr/StreamingZephyrShellThingSetBinaryEncoder.hpp"
 #include <array>
@@ -32,5 +33,11 @@ public:
 private:
     int onShellCommandExecuted(const shell *shell, size_t argc, char **argv);
 };
+
+/// @brief Set the text-mode rendering options. Call this before the first
+/// ``thingset`` shell command. The shell server is built on first
+/// request and snapshots this value once at init
+void setShellTextOptions(TextEncoderOptions opts);
+TextEncoderOptions getShellTextOptions();
 
 } // namespace ThingSet::Zephyr

--- a/src/ThingSetRequestContext.cpp
+++ b/src/ThingSetRequestContext.cpp
@@ -129,9 +129,11 @@ bool ThingSetBinaryRequestContext::setStatus(const ThingSetStatusCode &status)
 }
 
 #ifdef ENABLE_TEXT_MODE
-ThingSetTextRequestContext::ThingSetTextRequestContext(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize) :
+ThingSetTextRequestContext::ThingSetTextRequestContext(uint8_t *request, size_t requestLen,
+                                                       uint8_t *response, size_t responseSize,
+                                                       TextEncoderOptions opts) :
     _ThingSetRequestContext(request, response),
-    _encoder(reinterpret_cast<char *>(response) + 4, responseSize - 4),
+    _encoder(reinterpret_cast<char *>(response) + 4, responseSize - 4, opts),
     _decoder(reinterpret_cast<char *>(request) + 1, requestLen - 1)
 {
     // find first space, if any

--- a/src/ThingSetServer.cpp
+++ b/src/ThingSetServer.cpp
@@ -30,7 +30,7 @@ int _ThingSetServer::handleBinaryRequest(uint8_t *request, size_t requestLen, ui
 #ifdef ENABLE_TEXT_MODE
 int _ThingSetServer::handleTextRequest(uint8_t *request, size_t requestLen, uint8_t *response, size_t responseSize)
 {
-    ThingSetTextRequestContext context(request, requestLen, response, responseSize);
+    ThingSetTextRequestContext context(request, requestLen, response, responseSize, _textOpts);
     return handleRequest(context, request, requestLen, response, responseSize);
 }
 #endif // ENABLE_TEXT_MODE

--- a/src/ThingSetTextEncoder.cpp
+++ b/src/ThingSetTextEncoder.cpp
@@ -173,7 +173,12 @@ bool ThingSetTextEncoder::encodeMapStart(const uint32_t &)
 bool ThingSetTextEncoder::encodeMapEnd()
 {
     _depth--;
-    _responsePosition--;
+    // Every key-value pair is emitted with a trailing separator, so strip it
+    // here, but only if the last character actually is one. An empty map has
+    // no separator and we'd otherwise eat the opening '{'
+    if (_responsePosition > 0 && _responseBuffer[_responsePosition - 1] == ',') {
+        _responsePosition--;
+    }
     return append('}');
 }
 
@@ -196,7 +201,10 @@ bool ThingSetTextEncoder::encodeListStart(const uint32_t &)
 bool ThingSetTextEncoder::encodeListEnd()
 {
     _depth--;
-    _responsePosition--;
+    // As with encodeMapEnd: only strip the trailing separator if one exists
+    if (_responsePosition > 0 && _responseBuffer[_responsePosition - 1] == ',') {
+        _responsePosition--;
+    }
     return append(']');
 }
 
@@ -223,6 +231,19 @@ bool ThingSetTextEncoder::encodeKeyValuePairSeparator()
 bool ThingSetTextEncoder::encodeKeysAsIds() const
 {
     return false;
+}
+
+bool ThingSetTextEncoder::renderGroupAsSkeleton() const
+{
+#if defined(CONFIG_THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON) && CONFIG_THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON
+    // Only skeletonise when this group is nested inside something else. A
+    // direct query (e.g. `?SomeGroup`) enters encode() at depth 0 and renders
+    // full content; children of that group that are themselves groups are
+    // rendered at depth >= 1 and fall into the skeleton branch
+    return _depth > 0;
+#else
+    return false;
+#endif
 }
 
 } // namespace ThingSet

--- a/src/ThingSetTextEncoder.cpp
+++ b/src/ThingSetTextEncoder.cpp
@@ -241,17 +241,9 @@ bool ThingSetTextEncoder::encodeKeysAsIds() const
     return false;
 }
 
-bool ThingSetTextEncoder::renderGroupAsSkeleton() const
+bool ThingSetTextEncoder::renderGroupAsOutline() const
 {
-#if defined(CONFIG_THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON) && CONFIG_THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON
-    // Only skeletonise when this group is nested inside something else. A
-    // direct query (e.g. `?SomeGroup`) enters encode() at depth 0 and renders
-    // full content; children of that group that are themselves groups are
-    // rendered at depth >= 1 and fall into the skeleton branch
-    return _depth > 0;
-#else
-    return false;
-#endif
+    return any(_opts, TextEncoderOptions::outlineGroups) && _depth > 0;
 }
 
 } // namespace ThingSet

--- a/src/zephyr/ThingSetZephyrShellServerTransport.cpp
+++ b/src/zephyr/ThingSetZephyrShellServerTransport.cpp
@@ -25,6 +25,18 @@ bool ThingSetZephyrShellServerTransport::listen(std::function<int(const EmptyIde
     return true;
 }
 
+static TextEncoderOptions s_shellTextOpts = TextEncoderOptions::none;
+
+void setShellTextOptions(TextEncoderOptions opts)
+{
+    s_shellTextOpts = opts;
+}
+
+TextEncoderOptions getShellTextOptions()
+{
+    return s_shellTextOpts;
+}
+
 int ThingSetZephyrShellServerTransport::_onShellCommandExecuted(const shell *shell, size_t argc, char **argv)
 {
     static ThingSetZephyrShellServerTransport transport;
@@ -32,6 +44,7 @@ int ThingSetZephyrShellServerTransport::_onShellCommandExecuted(const shell *she
     static bool initialised = false;
     if (!initialised)
     {
+        server.setTextOptions(s_shellTextOpts);
         server.listen();
         initialised = true;
     }

--- a/tests/TestTextEncoder.cpp
+++ b/tests/TestTextEncoder.cpp
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "thingset++/ThingSet.hpp"
+#include "thingset++/ThingSetGroup.hpp"
+#include "thingset++/ThingSetProperty.hpp"
 #include "thingset++/ThingSetTextEncoder.hpp"
 #include "gtest/gtest.h"
 
@@ -421,5 +424,97 @@ TEST(TextEncoder, TestBoundaryEncode)
     SETUP(1) // make buffer of size 1 to ensure value cannot fit
     encoder.encode(1.23f);
     const char *expected = "";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+// Empty containers previously produced broken output (encodeMapEnd/encodeListEnd
+// unconditionally stripped the character before the closing brace, eating the
+// opening brace when no trailing separator existed). These two tests lock in the fix.
+TEST(TextEncoder, EncodeEmptyMap)
+{
+    SETUP(TEXT_ENCODER_BUFFER_SIZE)
+    encoder.encodeMapStart(0);
+    encoder.encodeMapEnd(0);
+    const char *expected = "{}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, EncodeEmptyList)
+{
+    SETUP(TEXT_ENCODER_BUFFER_SIZE)
+    encoder.encodeListStart(0);
+    encoder.encodeListEnd(0);
+    const char *expected = "[]";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+// Test double with a toggleable renderGroupAsSkeleton hook so we can exercise
+// the filtering logic in ThingSetGroup::encode without needing the CONFIG flag
+// (which would require a separate test binary).
+class SkeletonToggleTextEncoder : public ThingSetTextEncoder
+{
+public:
+    bool skeleton = false;
+    using ThingSetTextEncoder::ThingSetTextEncoder;
+    bool renderGroupAsSkeleton() const override
+    {
+        return skeleton;
+    }
+};
+
+TEST(TextEncoder, GroupEncodesFullWhenNotSkeleton)
+{
+    // IDs 0xA000+ chosen to avoid collisions with other tests.
+    ThingSetGroup<0xA000, 0, "topG"> top;
+    ThingSetReadOnlyProperty<int> leaf{ 0xA001, 0xA000, "leaf" };
+    leaf = 42;
+
+    char buffer[128];
+    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
+    encoder.skeleton = false;
+
+    top.encode(encoder);
+    const char *expected = "{\"leaf\":42}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, GroupEncodesSkeletonOmitsLeaves)
+{
+    // Top group holds a leaf property and a sub-group. Skeleton mode should
+    // drop the leaf and keep the sub-group.
+    ThingSetGroup<0xA010, 0, "topG"> top;
+    ThingSetReadOnlyProperty<int> leaf{ 0xA011, 0xA010, "leaf" };
+    ThingSetGroup<0xA012, 0xA010, "sub"> sub;
+    leaf = 99;
+
+    char buffer[128];
+    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
+    encoder.skeleton = true;
+
+    top.encode(encoder);
+    const char *expected = "{\"sub\":{}}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, GroupSkeletonRecurses)
+{
+    // Three-deep group chain with a leaf at each level. Skeleton should drop
+    // all leaves but preserve the group nesting structure.
+    ThingSetGroup<0xA020, 0, "L0"> l0;
+    ThingSetReadOnlyProperty<int> leaf0{ 0xA021, 0xA020, "x" };
+    ThingSetGroup<0xA022, 0xA020, "L1"> l1;
+    ThingSetReadOnlyProperty<int> leaf1{ 0xA023, 0xA022, "x" };
+    ThingSetGroup<0xA024, 0xA022, "L2"> l2;
+    ThingSetReadOnlyProperty<int> leaf2{ 0xA025, 0xA024, "x" };
+    leaf0 = 0;
+    leaf1 = 0;
+    leaf2 = 0;
+
+    char buffer[256];
+    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
+    encoder.skeleton = true;
+
+    l0.encode(encoder);
+    const char *expected = "{\"L1\":{\"L2\":{}}}";
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }

--- a/tests/TestTextEncoder.cpp
+++ b/tests/TestTextEncoder.cpp
@@ -448,21 +448,7 @@ TEST(TextEncoder, EncodeEmptyList)
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 
-// Test double with a toggleable renderGroupAsSkeleton hook so we can exercise
-// the filtering logic in ThingSetGroup::encode without needing the CONFIG flag
-// (which would require a separate test binary).
-class SkeletonToggleTextEncoder : public ThingSetTextEncoder
-{
-public:
-    bool skeleton = false;
-    using ThingSetTextEncoder::ThingSetTextEncoder;
-    bool renderGroupAsSkeleton() const override
-    {
-        return skeleton;
-    }
-};
-
-TEST(TextEncoder, GroupEncodesFullWhenNotSkeleton)
+TEST(TextEncoder, GroupEncodesFullByDefault)
 {
     // IDs 0xA000+ chosen to avoid collisions with other tests.
     ThingSetGroup<0xA000, 0, "topG"> top;
@@ -470,51 +456,63 @@ TEST(TextEncoder, GroupEncodesFullWhenNotSkeleton)
     leaf = 42;
 
     char buffer[128];
-    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
-    encoder.skeleton = false;
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer));  // default: TextEncoderOptions::none
 
     top.encode(encoder);
     const char *expected = "{\"leaf\":42}";
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 
-TEST(TextEncoder, GroupEncodesSkeletonOmitsLeaves)
+TEST(TextEncoder, OutlineOnlyAppliesToNestedGroups)
 {
-    // Top group holds a leaf property and a sub-group. Skeleton mode should
-    // drop the leaf and keep the sub-group.
-    ThingSetGroup<0xA010, 0, "topG"> top;
-    ThingSetReadOnlyProperty<int> leaf{ 0xA011, 0xA010, "leaf" };
+    ThingSetGroup<0xA010, 0, "outer"> outer;
+    ThingSetReadOnlyProperty<int> outerLeaf{ 0xA011, 0xA010, "ol" };
     ThingSetGroup<0xA012, 0xA010, "sub"> sub;
-    leaf = 99;
+    ThingSetReadOnlyProperty<int> subLeaf{ 0xA013, 0xA012, "sl" };
+    ThingSetGroup<0xA014, 0xA012, "leaf2"> deeper;
+    outerLeaf = 1;
+    subLeaf = 2;
 
     char buffer[128];
-    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
-    encoder.skeleton = true;
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::outlineGroups);
 
-    top.encode(encoder);
-    const char *expected = "{\"sub\":{}}";
+    outer.encode(encoder);
+    const char *expected = "{\"ol\":1,\"sub\":{\"leaf2\":{}}}";
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 
-TEST(TextEncoder, GroupSkeletonRecurses)
+TEST(TextEncoder, OutlineRecursesThroughNestedGroups)
 {
-    // Three-deep group chain with a leaf at each level. Skeleton should drop
-    // all leaves but preserve the group nesting structure.
     ThingSetGroup<0xA020, 0, "L0"> l0;
     ThingSetReadOnlyProperty<int> leaf0{ 0xA021, 0xA020, "x" };
     ThingSetGroup<0xA022, 0xA020, "L1"> l1;
     ThingSetReadOnlyProperty<int> leaf1{ 0xA023, 0xA022, "x" };
     ThingSetGroup<0xA024, 0xA022, "L2"> l2;
     ThingSetReadOnlyProperty<int> leaf2{ 0xA025, 0xA024, "x" };
+    ThingSetGroup<0xA026, 0xA024, "L3"> l3;
     leaf0 = 0;
     leaf1 = 0;
     leaf2 = 0;
 
     char buffer[256];
-    SkeletonToggleTextEncoder encoder(buffer, sizeof(buffer));
-    encoder.skeleton = true;
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::outlineGroups);
 
     l0.encode(encoder);
-    const char *expected = "{\"L1\":{\"L2\":{}}}";
+    const char *expected = "{\"x\":0,\"L1\":{\"L2\":{\"L3\":{}}}}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, DisplayFriendlyImpliesOutline)
+{
+    ThingSetGroup<0xA030, 0, "outer"> outer;
+    ThingSetGroup<0xA031, 0xA030, "sub"> sub;
+    ThingSetReadOnlyProperty<int> subLeaf{ 0xA032, 0xA031, "sl" };
+    subLeaf = 7;
+
+    char buffer[128];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::displayFriendly);
+
+    outer.encode(encoder);
+    const char *expected = "{\"sub\":{}}";
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -17,17 +17,6 @@ config THINGSET_PLUS_PLUS_PROTOCOL_TEXT
 	bool "Enable text mode"
 	default true
 
-config THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON
-	bool "Render nested groups as skeleton in text mode"
-	depends on THINGSET_PLUS_PLUS_PROTOCOL_TEXT
-	default n
-	help
-		When enabled, groups that appear nested inside a larger text-mode
-		response are rendered as a skeleton: only their own sub-groups
-		are emitted, and leaf values (properties, records, arrays) are
-		skipped. Direct queries (e.g. `?SomeGroup`) still render the group's
-		full content at the top level
-    
 config THINGSET_PLUS_PLUS_TEXT_FLOAT_PRECISION
 	int "Decimal places for floats/doubles in text-mode output"
 	depends on THINGSET_PLUS_PLUS_PROTOCOL_TEXT

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -17,6 +17,17 @@ config THINGSET_PLUS_PLUS_PROTOCOL_TEXT
 	bool "Enable text mode"
 	default true
 
+config THINGSET_PLUS_PLUS_TEXT_GROUP_SKELETON
+	bool "Render nested groups as skeleton in text mode"
+	depends on THINGSET_PLUS_PLUS_PROTOCOL_TEXT
+	default n
+	help
+		When enabled, groups that appear nested inside a larger text-mode
+		response are rendered as a skeleton: only their own sub-groups
+		are emitted, and leaf values (properties, records, arrays) are
+		skipped. Direct queries (e.g. `?SomeGroup`) still render the group's
+		full content at the top level
+
 config THINGSET_PLUS_PLUS_ENHANCED_REPORTING
 	bool "Enable enhanced reporting"
 	default false


### PR DESCRIPTION
See:

```
uart:~$ thingset ?HMCU
:85 {"NestedGroup":{"NestedGroup2":{}},"rIpAddr":"192.168.1.1"}
uart:~$ thingset ?HMCU/NestedGroup
:85 {"NestedGroupValue":17,"NestedGroup2":{}}
uart:~$ thingset ?HMCU/NestedGroup/NestedGroup2
:85 {"NestedGroupValue2":27}
```