### PR TITLE
Truncate long arrays in text mode via abbreviateArrays option

### DIFF
--- a/include/thingset++/ThingSetEncoder.hpp
+++ b/include/thingset++/ThingSetEncoder.hpp
@@ -243,9 +243,13 @@ public:
 
     template <typename T> bool encode(const T *value, const size_t &size)
     {
+        const size_t rendered = renderedListLength(size);
         bool result = encodeListStart(size);
-        for (size_t i = 0; i < size; i++) {
+        for (size_t i = 0; i < rendered; i++) {
             result &= this->encode(value[i]) && this->encodeListSeparator();
+        }
+        if (rendered < size) {
+            result &= encodeTruncationMarker() && this->encodeListSeparator();
         }
         return result && encodeListEnd(size);
     }
@@ -268,6 +272,23 @@ public:
     virtual bool renderGroupAsOutline() const
     {
         return false;
+    }
+
+    /// @brief Hook for encoders that want to render fewer elements than an
+    /// array actually contains (e.g. text mode with abbreviateArrays).
+    /// Return the number of elements to actually emit; values less than
+    /// ``size`` cause a truncation marker to be appended after the loop
+    virtual size_t renderedListLength(const size_t &size)
+    {
+        return size;
+    }
+
+    /// @brief Hook for encoders to append a truncation marker after a
+    /// truncated array. Default succeeds without writing anything; the
+    /// text encoder writes ``...`` so the abbreviation is human-visible
+    virtual bool encodeTruncationMarker()
+    {
+        return true;
     }
 
 protected:

--- a/include/thingset++/ThingSetTextEncoder.hpp
+++ b/include/thingset++/ThingSetTextEncoder.hpp
@@ -109,6 +109,8 @@ public:
 
     bool encodeKeysAsIds() const override;
     bool renderGroupAsOutline() const override;
+    size_t renderedListLength(const size_t &size) override;
+    bool encodeTruncationMarker() override;
 
 protected:
     bool encodeListSeparator() override;

--- a/src/ThingSetTextEncoder.cpp
+++ b/src/ThingSetTextEncoder.cpp
@@ -246,4 +246,21 @@ bool ThingSetTextEncoder::renderGroupAsOutline() const
     return any(_opts, TextEncoderOptions::outlineGroups) && _depth > 0;
 }
 
+size_t ThingSetTextEncoder::renderedListLength(const size_t &size)
+{
+#if defined(CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX) && CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX > 0
+    if (any(_opts, TextEncoderOptions::abbreviateArrays)
+        && _depth > 0
+        && size > (size_t)CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX) {
+        return CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX;
+    }
+#endif
+    return size;
+}
+
+bool ThingSetTextEncoder::encodeTruncationMarker()
+{
+    return append('.') && append('.') && append('.');
+}
+
 } // namespace ThingSet

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,4 +45,7 @@ endif()
 target_link_libraries(testapp PRIVATE thingset++)
 target_link_libraries(testapp PRIVATE gtest_main)
 
+target_compile_definitions(testapp PRIVATE CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX=3)
+target_compile_definitions(thingset++ PRIVATE CONFIG_THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX=3)
+
 enable_testing()

--- a/tests/TestTextEncoder.cpp
+++ b/tests/TestTextEncoder.cpp
@@ -419,6 +419,72 @@ TEST(TextEncoder, EncodeList)
     ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
 }
 
+namespace {
+template <size_t N>
+void encode_nested_array(ThingSetTextEncoder &encoder, const std::array<int, N> &arr)
+{
+    encoder.encodeMapStart(1);
+    encoder.encode(std::make_pair(std::string_view{"a"}, arr));
+    encoder.encodeMapEnd(1);
+}
+} // namespace
+
+TEST(TextEncoder, AbbreviateTruncatesNestedArray)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::abbreviateArrays);
+    std::array<int, 8> arr{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    encode_nested_array(encoder, arr);
+    const char *expected = "{\"a\":[1,2,3,...]}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, AbbreviateLeavesShortArrayAlone)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::abbreviateArrays);
+    std::array<int, 3> arr{ 1, 2, 3 };
+    encode_nested_array(encoder, arr);
+    const char *expected = "{\"a\":[1,2,3]}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, NoAbbreviateMeansNoTruncation)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer));  // default: none
+    std::array<int, 8> arr{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    encode_nested_array(encoder, arr);
+    const char *expected = "{\"a\":[1,2,3,4,5,6,7,8]}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, AbbreviateDoesNotTruncateTopLevelArray)
+{
+    char buffer[TEXT_ENCODER_BUFFER_SIZE];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::abbreviateArrays);
+    std::array<int, 8> arr{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    encoder.encode(arr);
+    const char *expected = "[1,2,3,4,5,6,7,8]";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
+TEST(TextEncoder, DisplayFriendlyTruncatesAndOutlines)
+{
+    ThingSetGroup<0xA040, 0, "outer"> outer;
+    ThingSetReadOnlyProperty<int> outerLeaf{ 0xA041, 0xA040, "ol" };
+    ThingSetGroup<0xA042, 0xA040, "sub"> sub;
+    ThingSetReadOnlyProperty<int> subLeaf{ 0xA043, 0xA042, "sl" };
+    outerLeaf = 1;
+    subLeaf = 2;
+
+    char buffer[256];
+    ThingSetTextEncoder encoder(buffer, sizeof(buffer), TextEncoderOptions::displayFriendly);
+    outer.encode(encoder);
+    const char *expected = "{\"ol\":1,\"sub\":{}}";
+    ASSERT_BUFFER_EQ(expected, buffer, encoder.getEncodedLength());
+}
+
 TEST(TextEncoder, TestBoundaryEncode)
 {
     SETUP(1) // make buffer of size 1 to ensure value cannot fit

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -26,6 +26,18 @@ config THINGSET_PLUS_PLUS_TEXT_FLOAT_PRECISION
 		Number of digits after the decimal point when encoding floats
 		and doubles via the text-mode encoder
 
+config THINGSET_PLUS_PLUS_TEXT_ARRAY_MAX
+	int "Max array elements to render in text mode (0 = unlimited)"
+	depends on THINGSET_PLUS_PLUS_PROTOCOL_TEXT
+	range 0 65535
+	default 0
+	help
+		Threshold used by the abbreviateArrays text rendering option.
+		When that option is set on the encoder and an array nested
+		inside a larger response is longer than this value, the first
+		N elements are rendered followed by a literal "..." marker.
+		Zero disables abbreviation regardless of the runtime option
+
 config THINGSET_PLUS_PLUS_ENHANCED_REPORTING
 	bool "Enable enhanced reporting"
 	default false


### PR DESCRIPTION
A continuation of the work in https://github.com/Brill-Power/thingsetplusplus/pull/60

```
uart:~$ thingset ?HMCU
:85 {"testArray":[1,2,3,4,"..."],"rIpAddr":"192.168.1.1"}
uart:~$ thingset ?HMCU/testArray
:85 [1,2,3,4,5,6,7,8,9,10]
```